### PR TITLE
feat: refactor backend into microservices architecture

### DIFF
--- a/docker-compose.microservices.yml
+++ b/docker-compose.microservices.yml
@@ -1,0 +1,167 @@
+version: '3.8'
+
+services:
+  # Infrastructure
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=WeddingBidders123!
+      - MSSQL_PID=Developer
+    ports:
+      - "1433:1433"
+    volumes:
+      - sqlserver-data:/var/opt/mssql
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P WeddingBidders123! -Q 'SELECT 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  # API Gateway
+  gateway:
+    build:
+      context: ./services
+      dockerfile: gateway/WeddingBidders.Gateway/Dockerfile
+    ports:
+      - "5000:8080"
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - Cors__Origins=http://localhost:4200
+      - ReverseProxy__Clusters__identity-cluster__Destinations__identity-destination__Address=http://identity:8080
+      - ReverseProxy__Clusters__wedding-cluster__Destinations__wedding-destination__Address=http://wedding:8080
+      - ReverseProxy__Clusters__bidding-cluster__Destinations__bidding-destination__Address=http://bidding:8080
+      - ReverseProxy__Clusters__messaging-cluster__Destinations__messaging-destination__Address=http://messaging:8080
+      - ReverseProxy__Clusters__subscription-cluster__Destinations__subscription-destination__Address=http://subscription:8080
+      - ReverseProxy__Clusters__support-cluster__Destinations__support-destination__Address=http://support:8080
+    depends_on:
+      - identity
+      - wedding
+      - bidding
+      - messaging
+      - subscription
+      - support
+
+  # Identity Service
+  identity:
+    build:
+      context: ./services
+      dockerfile: identity/WeddingBidders.Identity.Api/Dockerfile
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__IdentityConnection=Server=sqlserver;Database=WeddingBidders_Identity;User Id=sa;Password=WeddingBidders123!;TrustServerCertificate=True
+      - ConnectionStrings__Redis=redis:6379
+      - Jwt__SecretKey=WeddingBiddersSecretKeyForJwtTokenGenerationMustBe32CharsLong!
+      - Jwt__Issuer=localhost
+      - Jwt__Audience=all
+    depends_on:
+      sqlserver:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  # Wedding Service
+  wedding:
+    build:
+      context: ./services
+      dockerfile: wedding/WeddingBidders.Wedding.Api/Dockerfile
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__WeddingConnection=Server=sqlserver;Database=WeddingBidders_Wedding;User Id=sa;Password=WeddingBidders123!;TrustServerCertificate=True
+      - ConnectionStrings__Redis=redis:6379
+      - Jwt__SecretKey=WeddingBiddersSecretKeyForJwtTokenGenerationMustBe32CharsLong!
+      - Jwt__Issuer=localhost
+      - Jwt__Audience=all
+    depends_on:
+      sqlserver:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  # Bidding Service
+  bidding:
+    build:
+      context: ./services
+      dockerfile: bidding/WeddingBidders.Bidding.Api/Dockerfile
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__BiddingConnection=Server=sqlserver;Database=WeddingBidders_Bidding;User Id=sa;Password=WeddingBidders123!;TrustServerCertificate=True
+      - ConnectionStrings__Redis=redis:6379
+      - Jwt__SecretKey=WeddingBiddersSecretKeyForJwtTokenGenerationMustBe32CharsLong!
+      - Jwt__Issuer=localhost
+      - Jwt__Audience=all
+    depends_on:
+      sqlserver:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  # Messaging Service
+  messaging:
+    build:
+      context: ./services
+      dockerfile: messaging/WeddingBidders.Messaging.Api/Dockerfile
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__MessagingConnection=Server=sqlserver;Database=WeddingBidders_Messaging;User Id=sa;Password=WeddingBidders123!;TrustServerCertificate=True
+      - ConnectionStrings__Redis=redis:6379
+      - Jwt__SecretKey=WeddingBiddersSecretKeyForJwtTokenGenerationMustBe32CharsLong!
+      - Jwt__Issuer=localhost
+      - Jwt__Audience=all
+    depends_on:
+      sqlserver:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  # Subscription Service
+  subscription:
+    build:
+      context: ./services
+      dockerfile: subscription/WeddingBidders.Subscription.Api/Dockerfile
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__SubscriptionConnection=Server=sqlserver;Database=WeddingBidders_Subscription;User Id=sa;Password=WeddingBidders123!;TrustServerCertificate=True
+      - ConnectionStrings__Redis=redis:6379
+      - Jwt__SecretKey=WeddingBiddersSecretKeyForJwtTokenGenerationMustBe32CharsLong!
+      - Jwt__Issuer=localhost
+      - Jwt__Audience=all
+    depends_on:
+      sqlserver:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  # Support Service
+  support:
+    build:
+      context: ./services
+      dockerfile: support/WeddingBidders.Support.Api/Dockerfile
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__SupportConnection=Server=sqlserver;Database=WeddingBidders_Support;User Id=sa;Password=WeddingBidders123!;TrustServerCertificate=True
+      - ConnectionStrings__Redis=redis:6379
+      - Jwt__SecretKey=WeddingBiddersSecretKeyForJwtTokenGenerationMustBe32CharsLong!
+      - Jwt__Issuer=localhost
+      - Jwt__Audience=all
+    depends_on:
+      sqlserver:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+volumes:
+  redis-data:
+  sqlserver-data:

--- a/services/WeddingBidders.Microservices.sln
+++ b/services/WeddingBidders.Microservices.sln
@@ -1,0 +1,104 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "shared", "shared", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Shared.Core", "shared\WeddingBidders.Shared.Core\WeddingBidders.Shared.Core.csproj", "{22222222-2222-2222-2222-222222222201}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Shared.Messaging", "shared\WeddingBidders.Shared.Messaging\WeddingBidders.Shared.Messaging.csproj", "{22222222-2222-2222-2222-222222222202}"
+EndProject
+
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "identity", "identity", "{33333333-3333-3333-3333-333333333301}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Identity.Api", "identity\WeddingBidders.Identity.Api\WeddingBidders.Identity.Api.csproj", "{33333333-3333-3333-3333-333333333302}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Identity.Core", "identity\WeddingBidders.Identity.Core\WeddingBidders.Identity.Core.csproj", "{33333333-3333-3333-3333-333333333303}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Identity.Infrastructure", "identity\WeddingBidders.Identity.Infrastructure\WeddingBidders.Identity.Infrastructure.csproj", "{33333333-3333-3333-3333-333333333304}"
+EndProject
+
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "wedding", "wedding", "{44444444-4444-4444-4444-444444444401}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Wedding.Api", "wedding\WeddingBidders.Wedding.Api\WeddingBidders.Wedding.Api.csproj", "{44444444-4444-4444-4444-444444444402}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Wedding.Core", "wedding\WeddingBidders.Wedding.Core\WeddingBidders.Wedding.Core.csproj", "{44444444-4444-4444-4444-444444444403}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Wedding.Infrastructure", "wedding\WeddingBidders.Wedding.Infrastructure\WeddingBidders.Wedding.Infrastructure.csproj", "{44444444-4444-4444-4444-444444444404}"
+EndProject
+
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "bidding", "bidding", "{55555555-5555-5555-5555-555555555501}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Bidding.Api", "bidding\WeddingBidders.Bidding.Api\WeddingBidders.Bidding.Api.csproj", "{55555555-5555-5555-5555-555555555502}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Bidding.Core", "bidding\WeddingBidders.Bidding.Core\WeddingBidders.Bidding.Core.csproj", "{55555555-5555-5555-5555-555555555503}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Bidding.Infrastructure", "bidding\WeddingBidders.Bidding.Infrastructure\WeddingBidders.Bidding.Infrastructure.csproj", "{55555555-5555-5555-5555-555555555504}"
+EndProject
+
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "messaging", "messaging", "{66666666-6666-6666-6666-666666666601}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Messaging.Api", "messaging\WeddingBidders.Messaging.Api\WeddingBidders.Messaging.Api.csproj", "{66666666-6666-6666-6666-666666666602}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Messaging.Core", "messaging\WeddingBidders.Messaging.Core\WeddingBidders.Messaging.Core.csproj", "{66666666-6666-6666-6666-666666666603}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Messaging.Infrastructure", "messaging\WeddingBidders.Messaging.Infrastructure\WeddingBidders.Messaging.Infrastructure.csproj", "{66666666-6666-6666-6666-666666666604}"
+EndProject
+
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "subscription", "subscription", "{77777777-7777-7777-7777-777777777701}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Subscription.Api", "subscription\WeddingBidders.Subscription.Api\WeddingBidders.Subscription.Api.csproj", "{77777777-7777-7777-7777-777777777702}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Subscription.Core", "subscription\WeddingBidders.Subscription.Core\WeddingBidders.Subscription.Core.csproj", "{77777777-7777-7777-7777-777777777703}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Subscription.Infrastructure", "subscription\WeddingBidders.Subscription.Infrastructure\WeddingBidders.Subscription.Infrastructure.csproj", "{77777777-7777-7777-7777-777777777704}"
+EndProject
+
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "support", "support", "{88888888-8888-8888-8888-888888888801}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Support.Api", "support\WeddingBidders.Support.Api\WeddingBidders.Support.Api.csproj", "{88888888-8888-8888-8888-888888888802}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Support.Core", "support\WeddingBidders.Support.Core\WeddingBidders.Support.Core.csproj", "{88888888-8888-8888-8888-888888888803}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Support.Infrastructure", "support\WeddingBidders.Support.Infrastructure\WeddingBidders.Support.Infrastructure.csproj", "{88888888-8888-8888-8888-888888888804}"
+EndProject
+
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "gateway", "gateway", "{99999999-9999-9999-9999-999999999901}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeddingBidders.Gateway", "gateway\WeddingBidders.Gateway\WeddingBidders.Gateway.csproj", "{99999999-9999-9999-9999-999999999902}"
+EndProject
+
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{22222222-2222-2222-2222-222222222201} = {11111111-1111-1111-1111-111111111111}
+		{22222222-2222-2222-2222-222222222202} = {11111111-1111-1111-1111-111111111111}
+		{33333333-3333-3333-3333-333333333302} = {33333333-3333-3333-3333-333333333301}
+		{33333333-3333-3333-3333-333333333303} = {33333333-3333-3333-3333-333333333301}
+		{33333333-3333-3333-3333-333333333304} = {33333333-3333-3333-3333-333333333301}
+		{44444444-4444-4444-4444-444444444402} = {44444444-4444-4444-4444-444444444401}
+		{44444444-4444-4444-4444-444444444403} = {44444444-4444-4444-4444-444444444401}
+		{44444444-4444-4444-4444-444444444404} = {44444444-4444-4444-4444-444444444401}
+		{55555555-5555-5555-5555-555555555502} = {55555555-5555-5555-5555-555555555501}
+		{55555555-5555-5555-5555-555555555503} = {55555555-5555-5555-5555-555555555501}
+		{55555555-5555-5555-5555-555555555504} = {55555555-5555-5555-5555-555555555501}
+		{66666666-6666-6666-6666-666666666602} = {66666666-6666-6666-6666-666666666601}
+		{66666666-6666-6666-6666-666666666603} = {66666666-6666-6666-6666-666666666601}
+		{66666666-6666-6666-6666-666666666604} = {66666666-6666-6666-6666-666666666601}
+		{77777777-7777-7777-7777-777777777702} = {77777777-7777-7777-7777-777777777701}
+		{77777777-7777-7777-7777-777777777703} = {77777777-7777-7777-7777-777777777701}
+		{77777777-7777-7777-7777-777777777704} = {77777777-7777-7777-7777-777777777701}
+		{88888888-8888-8888-8888-888888888802} = {88888888-8888-8888-8888-888888888801}
+		{88888888-8888-8888-8888-888888888803} = {88888888-8888-8888-8888-888888888801}
+		{88888888-8888-8888-8888-888888888804} = {88888888-8888-8888-8888-888888888801}
+		{99999999-9999-9999-9999-999999999902} = {99999999-9999-9999-9999-999999999901}
+	EndGlobalSection
+EndGlobal

--- a/services/bidding/WeddingBidders.Bidding.Api/Controllers/BiddersController.cs
+++ b/services/bidding/WeddingBidders.Bidding.Api/Controllers/BiddersController.cs
@@ -1,0 +1,51 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using WeddingBidders.Bidding.Api.Features.Bidders;
+
+namespace WeddingBidders.Bidding.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class BiddersController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public BiddersController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost("register")]
+    public async Task<ActionResult<BidderDto>> RegisterBidder([FromBody] RegisterBidderRequest request)
+    {
+        try
+        {
+            var bidder = await _mediator.Send(request);
+            return CreatedAtAction(nameof(GetBidderById), new { id = bidder.BidderId }, bidder);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<BidderDto>>> GetAllBidders()
+    {
+        var bidders = await _mediator.Send(new GetAllBiddersRequest());
+        return Ok(bidders);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<BidderDto>> GetBidderById(Guid id)
+    {
+        var bidder = await _mediator.Send(new GetBidderByIdRequest { BidderId = id });
+        if (bidder == null)
+        {
+            return NotFound();
+        }
+        return Ok(bidder);
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Api/Controllers/BidsController.cs
+++ b/services/bidding/WeddingBidders.Bidding.Api/Controllers/BidsController.cs
@@ -1,0 +1,47 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using WeddingBidders.Bidding.Api.Features.Bids;
+
+namespace WeddingBidders.Bidding.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class BidsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public BidsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<BidDto>> CreateBid([FromBody] CreateBidRequest request)
+    {
+        try
+        {
+            var bid = await _mediator.Send(request);
+            return CreatedAtAction(nameof(GetBidsByWeddingId), new { weddingId = bid.WeddingId }, bid);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpGet("wedding/{weddingId:guid}")]
+    public async Task<ActionResult<List<BidDto>>> GetBidsByWeddingId(Guid weddingId)
+    {
+        var bids = await _mediator.Send(new GetBidsByWeddingIdRequest { WeddingId = weddingId });
+        return Ok(bids);
+    }
+
+    [HttpGet("bidder/{bidderId:guid}")]
+    public async Task<ActionResult<List<BidDto>>> GetBidsByBidderId(Guid bidderId)
+    {
+        var bids = await _mediator.Send(new GetBidsByBidderIdRequest { BidderId = bidderId });
+        return Ok(bids);
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Api/Dockerfile
+++ b/services/bidding/WeddingBidders.Bidding.Api/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["shared/WeddingBidders.Shared.Core/WeddingBidders.Shared.Core.csproj", "shared/WeddingBidders.Shared.Core/"]
+COPY ["shared/WeddingBidders.Shared.Messaging/WeddingBidders.Shared.Messaging.csproj", "shared/WeddingBidders.Shared.Messaging/"]
+COPY ["bidding/WeddingBidders.Bidding.Core/WeddingBidders.Bidding.Core.csproj", "bidding/WeddingBidders.Bidding.Core/"]
+COPY ["bidding/WeddingBidders.Bidding.Infrastructure/WeddingBidders.Bidding.Infrastructure.csproj", "bidding/WeddingBidders.Bidding.Infrastructure/"]
+COPY ["bidding/WeddingBidders.Bidding.Api/WeddingBidders.Bidding.Api.csproj", "bidding/WeddingBidders.Bidding.Api/"]
+RUN dotnet restore "bidding/WeddingBidders.Bidding.Api/WeddingBidders.Bidding.Api.csproj"
+COPY . .
+WORKDIR "/src/bidding/WeddingBidders.Bidding.Api"
+RUN dotnet build "WeddingBidders.Bidding.Api.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "WeddingBidders.Bidding.Api.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "WeddingBidders.Bidding.Api.dll"]

--- a/services/bidding/WeddingBidders.Bidding.Api/Features/Bidders/BidderDto.cs
+++ b/services/bidding/WeddingBidders.Bidding.Api/Features/Bidders/BidderDto.cs
@@ -1,0 +1,51 @@
+using WeddingBidders.Bidding.Core.Model;
+
+namespace WeddingBidders.Bidding.Api.Features.Bidders;
+
+public class BidderDto
+{
+    public Guid BidderId { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string? CompanyName { get; set; }
+    public string? Description { get; set; }
+    public Guid ProfileId { get; set; }
+    public string BidderType { get; set; } = string.Empty;
+    public bool IsApproved { get; set; }
+    public List<GalleryDto> Galleries { get; set; } = new();
+}
+
+public class GalleryDto
+{
+    public Guid GalleryId { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string Url { get; set; } = string.Empty;
+}
+
+public static class BidderExtensions
+{
+    public static BidderDto ToDto(this Bidder bidder)
+    {
+        return new BidderDto
+        {
+            BidderId = bidder.BidderId,
+            FirstName = bidder.FirstName,
+            LastName = bidder.LastName,
+            Email = bidder.Email,
+            CompanyName = bidder.CompanyName,
+            Description = bidder.Description,
+            ProfileId = bidder.ProfileId,
+            BidderType = bidder.BidderType.ToString(),
+            IsApproved = bidder.IsApproved,
+            Galleries = bidder.Galleries.Select(g => new GalleryDto
+            {
+                GalleryId = g.GalleryId,
+                Title = g.Title,
+                Description = g.Description,
+                Url = g.Url
+            }).ToList()
+        };
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Api/Features/Bidders/GetAllBidders.cs
+++ b/services/bidding/WeddingBidders.Bidding.Api/Features/Bidders/GetAllBidders.cs
@@ -1,0 +1,30 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Bidding.Core;
+
+namespace WeddingBidders.Bidding.Api.Features.Bidders;
+
+public class GetAllBiddersRequest : IRequest<List<BidderDto>>
+{
+}
+
+public class GetAllBiddersHandler : IRequestHandler<GetAllBiddersRequest, List<BidderDto>>
+{
+    private readonly IBiddingContext _context;
+
+    public GetAllBiddersHandler(IBiddingContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<BidderDto>> Handle(GetAllBiddersRequest request, CancellationToken cancellationToken)
+    {
+        var bidders = await _context.Bidders
+            .Include(b => b.Galleries)
+            .Where(b => b.IsApproved)
+            .OrderByDescending(b => b.CreatedDate)
+            .ToListAsync(cancellationToken);
+
+        return bidders.Select(b => b.ToDto()).ToList();
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Api/Features/Bidders/GetBidderById.cs
+++ b/services/bidding/WeddingBidders.Bidding.Api/Features/Bidders/GetBidderById.cs
@@ -1,0 +1,29 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Bidding.Core;
+
+namespace WeddingBidders.Bidding.Api.Features.Bidders;
+
+public class GetBidderByIdRequest : IRequest<BidderDto?>
+{
+    public Guid BidderId { get; set; }
+}
+
+public class GetBidderByIdHandler : IRequestHandler<GetBidderByIdRequest, BidderDto?>
+{
+    private readonly IBiddingContext _context;
+
+    public GetBidderByIdHandler(IBiddingContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<BidderDto?> Handle(GetBidderByIdRequest request, CancellationToken cancellationToken)
+    {
+        var bidder = await _context.Bidders
+            .Include(b => b.Galleries)
+            .FirstOrDefaultAsync(b => b.BidderId == request.BidderId, cancellationToken);
+
+        return bidder?.ToDto();
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Api/Features/Bidders/RegisterBidder.cs
+++ b/services/bidding/WeddingBidders.Bidding.Api/Features/Bidders/RegisterBidder.cs
@@ -1,0 +1,82 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Bidding.Core;
+using WeddingBidders.Bidding.Core.Model;
+using WeddingBidders.Shared.Core.Events;
+using WeddingBidders.Shared.Messaging;
+
+namespace WeddingBidders.Bidding.Api.Features.Bidders;
+
+public class RegisterBidderRequest : IRequest<BidderDto>
+{
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string? CompanyName { get; set; }
+    public string? Description { get; set; }
+    public Guid ProfileId { get; set; }
+    public BidderType BidderType { get; set; }
+}
+
+public class RegisterBidderRequestValidator : AbstractValidator<RegisterBidderRequest>
+{
+    public RegisterBidderRequestValidator()
+    {
+        RuleFor(x => x.FirstName).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.LastName).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.Email).NotEmpty().EmailAddress();
+        RuleFor(x => x.ProfileId).NotEmpty();
+    }
+}
+
+public class RegisterBidderHandler : IRequestHandler<RegisterBidderRequest, BidderDto>
+{
+    private readonly IBiddingContext _context;
+    private readonly IEventBus _eventBus;
+
+    public RegisterBidderHandler(IBiddingContext context, IEventBus eventBus)
+    {
+        _context = context;
+        _eventBus = eventBus;
+    }
+
+    public async Task<BidderDto> Handle(RegisterBidderRequest request, CancellationToken cancellationToken)
+    {
+        var emailExists = await _context.Bidders
+            .AnyAsync(b => b.Email.ToLower() == request.Email.ToLower(), cancellationToken);
+
+        if (emailExists)
+        {
+            throw new InvalidOperationException("Email already registered");
+        }
+
+        var bidder = new Bidder
+        {
+            BidderId = Guid.NewGuid(),
+            FirstName = request.FirstName,
+            LastName = request.LastName,
+            Email = request.Email,
+            CompanyName = request.CompanyName,
+            Description = request.Description,
+            ProfileId = request.ProfileId,
+            BidderType = request.BidderType,
+            IsApproved = false,
+            CreatedDate = DateTime.UtcNow
+        };
+
+        _context.Bidders.Add(bidder);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await _eventBus.PublishAsync(new BidderRegisteredEvent
+        {
+            BidderId = bidder.BidderId,
+            ProfileId = bidder.ProfileId,
+            Email = bidder.Email,
+            CompanyName = bidder.CompanyName ?? string.Empty,
+            BidderType = bidder.BidderType.ToString()
+        }, cancellationToken);
+
+        return bidder.ToDto();
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Api/Features/Bids/BidDto.cs
+++ b/services/bidding/WeddingBidders.Bidding.Api/Features/Bids/BidDto.cs
@@ -1,0 +1,31 @@
+using WeddingBidders.Bidding.Core.Model;
+
+namespace WeddingBidders.Bidding.Api.Features.Bids;
+
+public class BidDto
+{
+    public Guid BidId { get; set; }
+    public Guid WeddingId { get; set; }
+    public Guid BidderId { get; set; }
+    public decimal Price { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public DateTime CreatedDate { get; set; }
+}
+
+public static class BidExtensions
+{
+    public static BidDto ToDto(this Bid bid)
+    {
+        return new BidDto
+        {
+            BidId = bid.BidId,
+            WeddingId = bid.WeddingId,
+            BidderId = bid.BidderId,
+            Price = bid.Price,
+            Description = bid.Description,
+            Status = bid.Status.ToString(),
+            CreatedDate = bid.CreatedDate
+        };
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Api/Features/Bids/CreateBid.cs
+++ b/services/bidding/WeddingBidders.Bidding.Api/Features/Bids/CreateBid.cs
@@ -1,0 +1,81 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Bidding.Core;
+using WeddingBidders.Bidding.Core.Model;
+using WeddingBidders.Shared.Core.Events;
+using WeddingBidders.Shared.Messaging;
+
+namespace WeddingBidders.Bidding.Api.Features.Bids;
+
+public class CreateBidRequest : IRequest<BidDto>
+{
+    public Guid WeddingId { get; set; }
+    public Guid BidderId { get; set; }
+    public decimal Price { get; set; }
+    public string Description { get; set; } = string.Empty;
+}
+
+public class CreateBidRequestValidator : AbstractValidator<CreateBidRequest>
+{
+    public CreateBidRequestValidator()
+    {
+        RuleFor(x => x.WeddingId).NotEmpty();
+        RuleFor(x => x.BidderId).NotEmpty();
+        RuleFor(x => x.Price).GreaterThan(0);
+        RuleFor(x => x.Description).NotEmpty().MaximumLength(2000);
+    }
+}
+
+public class CreateBidHandler : IRequestHandler<CreateBidRequest, BidDto>
+{
+    private readonly IBiddingContext _context;
+    private readonly IEventBus _eventBus;
+
+    public CreateBidHandler(IBiddingContext context, IEventBus eventBus)
+    {
+        _context = context;
+        _eventBus = eventBus;
+    }
+
+    public async Task<BidDto> Handle(CreateBidRequest request, CancellationToken cancellationToken)
+    {
+        var bidder = await _context.Bidders
+            .FirstOrDefaultAsync(b => b.BidderId == request.BidderId, cancellationToken);
+
+        if (bidder == null)
+        {
+            throw new InvalidOperationException("Bidder not found");
+        }
+
+        if (!bidder.IsApproved)
+        {
+            throw new InvalidOperationException("Bidder is not approved");
+        }
+
+        var bid = new Bid
+        {
+            BidId = Guid.NewGuid(),
+            WeddingId = request.WeddingId,
+            BidderId = request.BidderId,
+            Price = request.Price,
+            Description = request.Description,
+            Status = BidStatus.Pending,
+            CreatedDate = DateTime.UtcNow
+        };
+
+        _context.Bids.Add(bid);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await _eventBus.PublishAsync(new BidCreatedEvent
+        {
+            BidId = bid.BidId,
+            WeddingId = bid.WeddingId,
+            BidderId = bid.BidderId,
+            Price = bid.Price,
+            Description = bid.Description
+        }, cancellationToken);
+
+        return bid.ToDto();
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Api/Features/Bids/GetBidsByBidderId.cs
+++ b/services/bidding/WeddingBidders.Bidding.Api/Features/Bids/GetBidsByBidderId.cs
@@ -1,0 +1,30 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Bidding.Core;
+
+namespace WeddingBidders.Bidding.Api.Features.Bids;
+
+public class GetBidsByBidderIdRequest : IRequest<List<BidDto>>
+{
+    public Guid BidderId { get; set; }
+}
+
+public class GetBidsByBidderIdHandler : IRequestHandler<GetBidsByBidderIdRequest, List<BidDto>>
+{
+    private readonly IBiddingContext _context;
+
+    public GetBidsByBidderIdHandler(IBiddingContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<BidDto>> Handle(GetBidsByBidderIdRequest request, CancellationToken cancellationToken)
+    {
+        var bids = await _context.Bids
+            .Where(b => b.BidderId == request.BidderId)
+            .OrderByDescending(b => b.CreatedDate)
+            .ToListAsync(cancellationToken);
+
+        return bids.Select(b => b.ToDto()).ToList();
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Api/Features/Bids/GetBidsByWeddingId.cs
+++ b/services/bidding/WeddingBidders.Bidding.Api/Features/Bids/GetBidsByWeddingId.cs
@@ -1,0 +1,30 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Bidding.Core;
+
+namespace WeddingBidders.Bidding.Api.Features.Bids;
+
+public class GetBidsByWeddingIdRequest : IRequest<List<BidDto>>
+{
+    public Guid WeddingId { get; set; }
+}
+
+public class GetBidsByWeddingIdHandler : IRequestHandler<GetBidsByWeddingIdRequest, List<BidDto>>
+{
+    private readonly IBiddingContext _context;
+
+    public GetBidsByWeddingIdHandler(IBiddingContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<BidDto>> Handle(GetBidsByWeddingIdRequest request, CancellationToken cancellationToken)
+    {
+        var bids = await _context.Bids
+            .Where(b => b.WeddingId == request.WeddingId)
+            .OrderByDescending(b => b.CreatedDate)
+            .ToListAsync(cancellationToken);
+
+        return bids.Select(b => b.ToDto()).ToList();
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Api/Program.cs
+++ b/services/bidding/WeddingBidders.Bidding.Api/Program.cs
@@ -1,0 +1,150 @@
+using System.Text;
+using FluentValidation;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using Serilog;
+using WeddingBidders.Bidding.Core;
+using WeddingBidders.Bidding.Infrastructure;
+using WeddingBidders.Bidding.Infrastructure.Seeding;
+using WeddingBidders.Shared.Messaging;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Configure Serilog
+Log.Logger = new LoggerConfiguration()
+    .ReadFrom.Configuration(builder.Configuration)
+    .Enrich.FromLogContext()
+    .WriteTo.Console()
+    .CreateLogger();
+
+builder.Host.UseSerilog();
+
+// Add services to the container
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Bidding Service API", Version = "v1" });
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Description = "JWT Authorization header using the Bearer scheme",
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = "Bearer"
+    });
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+});
+
+// Database - Bidding Service has its own database
+builder.Services.AddDbContext<BiddingContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("BiddingConnection")));
+builder.Services.AddScoped<IBiddingContext>(sp => sp.GetRequiredService<BiddingContext>());
+builder.Services.AddScoped<BiddingSeedingService>();
+
+// Redis Event Bus with MessagePack serialization
+builder.Services.AddRedisEventBus(builder.Configuration.GetConnectionString("Redis")!);
+
+// MediatR
+builder.Services.AddMediatR(cfg =>
+{
+    cfg.RegisterServicesFromAssembly(typeof(Program).Assembly);
+});
+
+// FluentValidation
+builder.Services.AddValidatorsFromAssembly(typeof(Program).Assembly);
+
+// Authorization
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddAuthorization();
+
+// JWT Authentication
+var jwtKey = builder.Configuration["Jwt:SecretKey"]!;
+var jwtIssuer = builder.Configuration["Jwt:Issuer"]!;
+var jwtAudience = builder.Configuration["Jwt:Audience"]!;
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddJwtBearer(options =>
+{
+    options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
+    options.SaveToken = true;
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey)),
+        ValidateIssuer = true,
+        ValidIssuer = jwtIssuer,
+        ValidateAudience = true,
+        ValidAudience = jwtAudience,
+        ValidateLifetime = true,
+        ClockSkew = TimeSpan.Zero
+    };
+});
+
+// CORS
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("CorsPolicy", policy =>
+    {
+        var origins = builder.Configuration["Cors:Origins"]?.Split(',') ?? Array.Empty<string>();
+        policy.WithOrigins(origins)
+            .AllowAnyMethod()
+            .AllowAnyHeader()
+            .AllowCredentials();
+    });
+});
+
+var app = builder.Build();
+
+// Seed database
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider.GetRequiredService<BiddingContext>();
+
+    if (app.Environment.IsDevelopment())
+    {
+        await context.Database.EnsureCreatedAsync();
+        var seeder = scope.ServiceProvider.GetRequiredService<BiddingSeedingService>();
+        await seeder.SeedAsync();
+    }
+}
+
+// Configure the HTTP request pipeline
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseCors("CorsPolicy");
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.UseSerilogRequestLogging();
+
+app.MapControllers();
+
+app.Run();
+
+public partial class Program { }

--- a/services/bidding/WeddingBidders.Bidding.Api/WeddingBidders.Bidding.Api.csproj
+++ b/services/bidding/WeddingBidders.Bidding.Api/WeddingBidders.Bidding.Api.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="MediatR" Version="12.2.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WeddingBidders.Bidding.Core\WeddingBidders.Bidding.Core.csproj" />
+    <ProjectReference Include="..\WeddingBidders.Bidding.Infrastructure\WeddingBidders.Bidding.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\shared\WeddingBidders.Shared.Messaging\WeddingBidders.Shared.Messaging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/bidding/WeddingBidders.Bidding.Api/appsettings.json
+++ b/services/bidding/WeddingBidders.Bidding.Api/appsettings.json
@@ -1,0 +1,47 @@
+{
+  "Serilog": {
+    "Using": ["Serilog.Sinks.Console", "Serilog.Sinks.File"],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning",
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}"
+        }
+      },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "logs/bidding-service-.log",
+          "rollingInterval": "Day"
+        }
+      }
+    ],
+    "Enrich": ["FromLogContext", "WithMachineName", "WithEnvironmentName"],
+    "Properties": {
+      "Application": "BiddingService"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "BiddingConnection": "Server=localhost;Database=WeddingBidders_Bidding;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True",
+    "Redis": "localhost:6379"
+  },
+  "Jwt": {
+    "SecretKey": "WeddingBiddersSecretKeyForJwtTokenGenerationMustBe32CharsLong!",
+    "Issuer": "localhost",
+    "Audience": "all",
+    "ExpirationMinutes": 10080
+  },
+  "Cors": {
+    "Origins": "http://localhost:4200"
+  }
+}

--- a/services/bidding/WeddingBidders.Bidding.Core/IBiddingContext.cs
+++ b/services/bidding/WeddingBidders.Bidding.Core/IBiddingContext.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Bidding.Core.Model;
+
+namespace WeddingBidders.Bidding.Core;
+
+public interface IBiddingContext
+{
+    DbSet<Bidder> Bidders { get; }
+    DbSet<Bid> Bids { get; }
+    DbSet<Gallery> Galleries { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/services/bidding/WeddingBidders.Bidding.Core/Model/Bid.cs
+++ b/services/bidding/WeddingBidders.Bidding.Core/Model/Bid.cs
@@ -1,0 +1,22 @@
+using WeddingBidders.Shared.Core;
+
+namespace WeddingBidders.Bidding.Core.Model;
+
+public class Bid : BaseEntity
+{
+    public Guid BidId { get; set; }
+    public Guid WeddingId { get; set; }
+    public Guid BidderId { get; set; }
+    public Bidder? Bidder { get; set; }
+    public decimal Price { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public BidStatus Status { get; set; }
+}
+
+public enum BidStatus
+{
+    Pending = 0,
+    Accepted = 1,
+    Rejected = 2,
+    Withdrawn = 3
+}

--- a/services/bidding/WeddingBidders.Bidding.Core/Model/Bidder.cs
+++ b/services/bidding/WeddingBidders.Bidding.Core/Model/Bidder.cs
@@ -1,0 +1,31 @@
+using WeddingBidders.Shared.Core;
+
+namespace WeddingBidders.Bidding.Core.Model;
+
+public class Bidder : BaseEntity
+{
+    public Guid BidderId { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string? CompanyName { get; set; }
+    public string? Description { get; set; }
+    public Guid ProfileId { get; set; }
+    public BidderType BidderType { get; set; }
+    public bool IsApproved { get; set; }
+    public ICollection<Gallery> Galleries { get; set; } = new List<Gallery>();
+    public ICollection<Bid> Bids { get; set; } = new List<Bid>();
+}
+
+public enum BidderType
+{
+    Photographer = 0,
+    Videographer = 1,
+    Caterer = 2,
+    Florist = 3,
+    DJ = 4,
+    Band = 5,
+    Planner = 6,
+    Decorator = 7,
+    Other = 8
+}

--- a/services/bidding/WeddingBidders.Bidding.Core/Model/Gallery.cs
+++ b/services/bidding/WeddingBidders.Bidding.Core/Model/Gallery.cs
@@ -1,0 +1,11 @@
+namespace WeddingBidders.Bidding.Core.Model;
+
+public class Gallery
+{
+    public Guid GalleryId { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string Url { get; set; } = string.Empty;
+    public Guid BidderId { get; set; }
+    public Bidder? Bidder { get; set; }
+}

--- a/services/bidding/WeddingBidders.Bidding.Core/WeddingBidders.Bidding.Core.csproj
+++ b/services/bidding/WeddingBidders.Bidding.Core/WeddingBidders.Bidding.Core.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\shared\WeddingBidders.Shared.Core\WeddingBidders.Shared.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/bidding/WeddingBidders.Bidding.Infrastructure/BiddingContext.cs
+++ b/services/bidding/WeddingBidders.Bidding.Infrastructure/BiddingContext.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Bidding.Core;
+using WeddingBidders.Bidding.Core.Model;
+
+namespace WeddingBidders.Bidding.Infrastructure;
+
+public class BiddingContext : DbContext, IBiddingContext
+{
+    public BiddingContext(DbContextOptions<BiddingContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Bidder> Bidders => Set<Bidder>();
+    public DbSet<Bid> Bids => Set<Bid>();
+    public DbSet<Gallery> Galleries => Set<Gallery>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(BiddingContext).Assembly);
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Infrastructure/Configurations/BidConfiguration.cs
+++ b/services/bidding/WeddingBidders.Bidding.Infrastructure/Configurations/BidConfiguration.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WeddingBidders.Bidding.Core.Model;
+
+namespace WeddingBidders.Bidding.Infrastructure.Configurations;
+
+public class BidConfiguration : IEntityTypeConfiguration<Bid>
+{
+    public void Configure(EntityTypeBuilder<Bid> builder)
+    {
+        builder.HasKey(b => b.BidId);
+        builder.Property(b => b.Price).HasPrecision(18, 2);
+        builder.Property(b => b.Description).HasMaxLength(2000);
+        builder.HasQueryFilter(b => !b.IsDeleted);
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Infrastructure/Configurations/BidderConfiguration.cs
+++ b/services/bidding/WeddingBidders.Bidding.Infrastructure/Configurations/BidderConfiguration.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WeddingBidders.Bidding.Core.Model;
+
+namespace WeddingBidders.Bidding.Infrastructure.Configurations;
+
+public class BidderConfiguration : IEntityTypeConfiguration<Bidder>
+{
+    public void Configure(EntityTypeBuilder<Bidder> builder)
+    {
+        builder.HasKey(b => b.BidderId);
+        builder.Property(b => b.FirstName).IsRequired().HasMaxLength(100);
+        builder.Property(b => b.LastName).IsRequired().HasMaxLength(100);
+        builder.Property(b => b.Email).IsRequired().HasMaxLength(255);
+        builder.Property(b => b.CompanyName).HasMaxLength(200);
+        builder.Property(b => b.Description).HasMaxLength(2000);
+        builder.HasIndex(b => b.Email).IsUnique();
+        builder.HasQueryFilter(b => !b.IsDeleted);
+
+        builder.HasMany(b => b.Galleries)
+            .WithOne(g => g.Bidder)
+            .HasForeignKey(g => g.BidderId);
+
+        builder.HasMany(b => b.Bids)
+            .WithOne(bid => bid.Bidder)
+            .HasForeignKey(bid => bid.BidderId);
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Infrastructure/Configurations/GalleryConfiguration.cs
+++ b/services/bidding/WeddingBidders.Bidding.Infrastructure/Configurations/GalleryConfiguration.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WeddingBidders.Bidding.Core.Model;
+
+namespace WeddingBidders.Bidding.Infrastructure.Configurations;
+
+public class GalleryConfiguration : IEntityTypeConfiguration<Gallery>
+{
+    public void Configure(EntityTypeBuilder<Gallery> builder)
+    {
+        builder.HasKey(g => g.GalleryId);
+        builder.Property(g => g.Title).IsRequired().HasMaxLength(200);
+        builder.Property(g => g.Description).HasMaxLength(1000);
+        builder.Property(g => g.Url).IsRequired().HasMaxLength(500);
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Infrastructure/Seeding/BiddingSeedingService.cs
+++ b/services/bidding/WeddingBidders.Bidding.Infrastructure/Seeding/BiddingSeedingService.cs
@@ -1,0 +1,19 @@
+using WeddingBidders.Bidding.Core;
+
+namespace WeddingBidders.Bidding.Infrastructure.Seeding;
+
+public class BiddingSeedingService
+{
+    private readonly IBiddingContext _context;
+
+    public BiddingSeedingService(IBiddingContext context)
+    {
+        _context = context;
+    }
+
+    public async Task SeedAsync()
+    {
+        // Bidders are registered through the API, no global seeding needed
+        await Task.CompletedTask;
+    }
+}

--- a/services/bidding/WeddingBidders.Bidding.Infrastructure/WeddingBidders.Bidding.Infrastructure.csproj
+++ b/services/bidding/WeddingBidders.Bidding.Infrastructure/WeddingBidders.Bidding.Infrastructure.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WeddingBidders.Bidding.Core\WeddingBidders.Bidding.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/gateway/WeddingBidders.Gateway/Dockerfile
+++ b/services/gateway/WeddingBidders.Gateway/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["gateway/WeddingBidders.Gateway/WeddingBidders.Gateway.csproj", "gateway/WeddingBidders.Gateway/"]
+RUN dotnet restore "gateway/WeddingBidders.Gateway/WeddingBidders.Gateway.csproj"
+COPY . .
+WORKDIR "/src/gateway/WeddingBidders.Gateway"
+RUN dotnet build "WeddingBidders.Gateway.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "WeddingBidders.Gateway.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "WeddingBidders.Gateway.dll"]

--- a/services/gateway/WeddingBidders.Gateway/Program.cs
+++ b/services/gateway/WeddingBidders.Gateway/Program.cs
@@ -1,0 +1,37 @@
+using Serilog;
+
+var builder = WebApplication.CreateBuilder(args);
+
+Log.Logger = new LoggerConfiguration()
+    .ReadFrom.Configuration(builder.Configuration)
+    .Enrich.FromLogContext()
+    .WriteTo.Console()
+    .CreateLogger();
+
+builder.Host.UseSerilog();
+
+// Add YARP reverse proxy
+builder.Services.AddReverseProxy()
+    .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
+
+// CORS
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("CorsPolicy", policy =>
+    {
+        var origins = builder.Configuration["Cors:Origins"]?.Split(',') ?? Array.Empty<string>();
+        policy.WithOrigins(origins)
+            .AllowAnyMethod()
+            .AllowAnyHeader()
+            .AllowCredentials();
+    });
+});
+
+var app = builder.Build();
+
+app.UseCors("CorsPolicy");
+app.UseSerilogRequestLogging();
+
+app.MapReverseProxy();
+
+app.Run();

--- a/services/gateway/WeddingBidders.Gateway/WeddingBidders.Gateway.csproj
+++ b/services/gateway/WeddingBidders.Gateway/WeddingBidders.Gateway.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Yarp.ReverseProxy" Version="2.1.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/services/gateway/WeddingBidders.Gateway/appsettings.json
+++ b/services/gateway/WeddingBidders.Gateway/appsettings.json
@@ -1,0 +1,129 @@
+{
+  "Serilog": {
+    "MinimumLevel": { "Default": "Information" },
+    "WriteTo": [{ "Name": "Console" }],
+    "Properties": { "Application": "ApiGateway" }
+  },
+  "AllowedHosts": "*",
+  "Cors": {
+    "Origins": "http://localhost:4200"
+  },
+  "ReverseProxy": {
+    "Routes": {
+      "identity-route": {
+        "ClusterId": "identity-cluster",
+        "Match": {
+          "Path": "/api/identity/{**catch-all}"
+        },
+        "Transforms": [
+          { "PathRemovePrefix": "/api/identity" },
+          { "PathPrefix": "/api" }
+        ]
+      },
+      "users-route": {
+        "ClusterId": "identity-cluster",
+        "Match": {
+          "Path": "/api/users/{**catch-all}"
+        }
+      },
+      "profiles-route": {
+        "ClusterId": "identity-cluster",
+        "Match": {
+          "Path": "/api/profiles/{**catch-all}"
+        }
+      },
+      "accounts-route": {
+        "ClusterId": "identity-cluster",
+        "Match": {
+          "Path": "/api/accounts/{**catch-all}"
+        }
+      },
+      "weddings-route": {
+        "ClusterId": "wedding-cluster",
+        "Match": {
+          "Path": "/api/weddings/{**catch-all}"
+        }
+      },
+      "customers-route": {
+        "ClusterId": "wedding-cluster",
+        "Match": {
+          "Path": "/api/customers/{**catch-all}"
+        }
+      },
+      "bidders-route": {
+        "ClusterId": "bidding-cluster",
+        "Match": {
+          "Path": "/api/bidders/{**catch-all}"
+        }
+      },
+      "bids-route": {
+        "ClusterId": "bidding-cluster",
+        "Match": {
+          "Path": "/api/bids/{**catch-all}"
+        }
+      },
+      "messages-route": {
+        "ClusterId": "messaging-cluster",
+        "Match": {
+          "Path": "/api/messages/{**catch-all}"
+        }
+      },
+      "subscriptions-route": {
+        "ClusterId": "subscription-cluster",
+        "Match": {
+          "Path": "/api/subscriptions/{**catch-all}"
+        }
+      },
+      "issues-route": {
+        "ClusterId": "support-cluster",
+        "Match": {
+          "Path": "/api/issues/{**catch-all}"
+        }
+      }
+    },
+    "Clusters": {
+      "identity-cluster": {
+        "Destinations": {
+          "identity-destination": {
+            "Address": "http://localhost:5001"
+          }
+        }
+      },
+      "wedding-cluster": {
+        "Destinations": {
+          "wedding-destination": {
+            "Address": "http://localhost:5002"
+          }
+        }
+      },
+      "bidding-cluster": {
+        "Destinations": {
+          "bidding-destination": {
+            "Address": "http://localhost:5003"
+          }
+        }
+      },
+      "messaging-cluster": {
+        "Destinations": {
+          "messaging-destination": {
+            "Address": "http://localhost:5004"
+          }
+        }
+      },
+      "subscription-cluster": {
+        "Destinations": {
+          "subscription-destination": {
+            "Address": "http://localhost:5005"
+          }
+        }
+      },
+      "support-cluster": {
+        "Destinations": {
+          "support-destination": {
+            "Address": "http://localhost:5006"
+          }
+        }
+      }
+    }
+  }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Behaviours/LoggingBehavior.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Behaviours/LoggingBehavior.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics;
+using MediatR;
+
+namespace WeddingBidders.Identity.Api.Behaviours;
+
+public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly ILogger<LoggingBehavior<TRequest, TResponse>> _logger;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public LoggingBehavior(ILogger<LoggingBehavior<TRequest, TResponse>> logger, IHttpContextAccessor httpContextAccessor)
+    {
+        _logger = logger;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        var requestName = typeof(TRequest).Name;
+        var userId = _httpContextAccessor.HttpContext?.User.FindFirst("UserId")?.Value ?? "Anonymous";
+
+        _logger.LogInformation("Handling {RequestName} for User {UserId}", requestName, userId);
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            var response = await next();
+            stopwatch.Stop();
+
+            _logger.LogInformation("Handled {RequestName} for User {UserId} in {ElapsedMilliseconds}ms",
+                requestName, userId, stopwatch.ElapsedMilliseconds);
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            _logger.LogError(ex, "Error handling {RequestName} for User {UserId} after {ElapsedMilliseconds}ms",
+                requestName, userId, stopwatch.ElapsedMilliseconds);
+            throw;
+        }
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Behaviours/ValidationBehavior.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Behaviours/ValidationBehavior.cs
@@ -1,0 +1,39 @@
+using FluentValidation;
+using MediatR;
+
+namespace WeddingBidders.Identity.Api.Behaviours;
+
+public class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly IEnumerable<IValidator<TRequest>> _validators;
+
+    public ValidationBehavior(IEnumerable<IValidator<TRequest>> validators)
+    {
+        _validators = validators;
+    }
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        if (!_validators.Any())
+        {
+            return await next();
+        }
+
+        var context = new ValidationContext<TRequest>(request);
+        var validationResults = await Task.WhenAll(
+            _validators.Select(v => v.ValidateAsync(context, cancellationToken)));
+
+        var failures = validationResults
+            .SelectMany(r => r.Errors)
+            .Where(f => f != null)
+            .ToList();
+
+        if (failures.Count != 0)
+        {
+            throw new ValidationException(failures);
+        }
+
+        return await next();
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Controllers/AccountsController.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Controllers/AccountsController.cs
@@ -1,0 +1,30 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using WeddingBidders.Identity.Api.Features.Accounts;
+
+namespace WeddingBidders.Identity.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class AccountsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public AccountsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet("current")]
+    public async Task<ActionResult<AccountDto>> GetCurrentAccount()
+    {
+        var account = await _mediator.Send(new GetCurrentAccountRequest());
+        if (account == null)
+        {
+            return NotFound();
+        }
+        return Ok(account);
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Controllers/IdentityController.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Controllers/IdentityController.cs
@@ -1,0 +1,44 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using WeddingBidders.Identity.Api.Features.Identity;
+
+namespace WeddingBidders.Identity.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class IdentityController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public IdentityController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost("authenticate")]
+    public async Task<ActionResult<AuthenticateResponse>> Authenticate([FromBody] AuthenticateRequest request)
+    {
+        try
+        {
+            var response = await _mediator.Send(request);
+            return Ok(response);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return Unauthorized(new { message = ex.Message });
+        }
+    }
+
+    [Authorize]
+    [HttpGet("current")]
+    public async Task<ActionResult> GetCurrentUser()
+    {
+        var user = await _mediator.Send(new GetCurrentUserRequest());
+        if (user == null)
+        {
+            return NotFound();
+        }
+        return Ok(user);
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Controllers/ProfilesController.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Controllers/ProfilesController.cs
@@ -1,0 +1,55 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using WeddingBidders.Identity.Api.Features.Profiles;
+
+namespace WeddingBidders.Identity.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class ProfilesController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public ProfilesController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<ProfileDto>> CreateProfile([FromBody] CreateProfileRequest request)
+    {
+        try
+        {
+            var profile = await _mediator.Send(request);
+            return CreatedAtAction(nameof(GetProfileById), new { id = profile.ProfileId }, profile);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<ProfileDto>> GetProfileById(Guid id)
+    {
+        var profile = await _mediator.Send(new GetProfileByIdRequest { ProfileId = id });
+        if (profile == null)
+        {
+            return NotFound();
+        }
+        return Ok(profile);
+    }
+
+    [HttpGet("current")]
+    public async Task<ActionResult<ProfileDto>> GetCurrentProfile()
+    {
+        var profile = await _mediator.Send(new GetCurrentProfileRequest());
+        if (profile == null)
+        {
+            return NotFound();
+        }
+        return Ok(profile);
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Controllers/UsersController.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Controllers/UsersController.cs
@@ -1,0 +1,56 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using WeddingBidders.Identity.Api.Features.Users;
+
+namespace WeddingBidders.Identity.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class UsersController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public UsersController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost]
+    [AllowAnonymous]
+    public async Task<ActionResult<UserDto>> CreateUser([FromBody] CreateUserRequest request)
+    {
+        try
+        {
+            var user = await _mediator.Send(request);
+            return CreatedAtAction(nameof(GetUserById), new { id = user.UserId }, user);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<UserDto>> GetUserById(Guid id)
+    {
+        var user = await _mediator.Send(new GetUserByIdRequest { UserId = id });
+        if (user == null)
+        {
+            return NotFound();
+        }
+        return Ok(user);
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<ActionResult> DeleteUser(Guid id)
+    {
+        var result = await _mediator.Send(new DeleteUserRequest { UserId = id });
+        if (!result)
+        {
+            return NotFound();
+        }
+        return NoContent();
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Dockerfile
+++ b/services/identity/WeddingBidders.Identity.Api/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["shared/WeddingBidders.Shared.Core/WeddingBidders.Shared.Core.csproj", "shared/WeddingBidders.Shared.Core/"]
+COPY ["shared/WeddingBidders.Shared.Messaging/WeddingBidders.Shared.Messaging.csproj", "shared/WeddingBidders.Shared.Messaging/"]
+COPY ["identity/WeddingBidders.Identity.Core/WeddingBidders.Identity.Core.csproj", "identity/WeddingBidders.Identity.Core/"]
+COPY ["identity/WeddingBidders.Identity.Infrastructure/WeddingBidders.Identity.Infrastructure.csproj", "identity/WeddingBidders.Identity.Infrastructure/"]
+COPY ["identity/WeddingBidders.Identity.Api/WeddingBidders.Identity.Api.csproj", "identity/WeddingBidders.Identity.Api/"]
+RUN dotnet restore "identity/WeddingBidders.Identity.Api/WeddingBidders.Identity.Api.csproj"
+COPY . .
+WORKDIR "/src/identity/WeddingBidders.Identity.Api"
+RUN dotnet build "WeddingBidders.Identity.Api.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "WeddingBidders.Identity.Api.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "WeddingBidders.Identity.Api.dll"]

--- a/services/identity/WeddingBidders.Identity.Api/Features/Accounts/AccountDto.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Features/Accounts/AccountDto.cs
@@ -1,0 +1,27 @@
+using WeddingBidders.Identity.Core.Model;
+
+namespace WeddingBidders.Identity.Api.Features.Accounts;
+
+public class AccountDto
+{
+    public Guid AccountId { get; set; }
+    public string AccountType { get; set; } = string.Empty;
+    public string AccountStatus { get; set; } = string.Empty;
+    public Guid UserId { get; set; }
+    public List<Guid> ProfileIds { get; set; } = new();
+}
+
+public static class AccountExtensions
+{
+    public static AccountDto ToDto(this Account account)
+    {
+        return new AccountDto
+        {
+            AccountId = account.AccountId,
+            AccountType = account.AccountType.ToString(),
+            AccountStatus = account.AccountStatus.ToString(),
+            UserId = account.UserId,
+            ProfileIds = account.Profiles.Select(p => p.ProfileId).ToList()
+        };
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Features/Accounts/GetCurrentAccount.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Features/Accounts/GetCurrentAccount.cs
@@ -1,0 +1,37 @@
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Identity.Core;
+
+namespace WeddingBidders.Identity.Api.Features.Accounts;
+
+public class GetCurrentAccountRequest : IRequest<AccountDto?>
+{
+}
+
+public class GetCurrentAccountHandler : IRequestHandler<GetCurrentAccountRequest, AccountDto?>
+{
+    private readonly IIdentityContext _context;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public GetCurrentAccountHandler(IIdentityContext context, IHttpContextAccessor httpContextAccessor)
+    {
+        _context = context;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<AccountDto?> Handle(GetCurrentAccountRequest request, CancellationToken cancellationToken)
+    {
+        var username = _httpContextAccessor.HttpContext?.User.Identity?.Name;
+        if (string.IsNullOrEmpty(username))
+        {
+            return null;
+        }
+
+        var account = await _context.Accounts
+            .Include(a => a.Profiles)
+            .FirstOrDefaultAsync(a => a.User != null && a.User.Username == username, cancellationToken);
+
+        return account?.ToDto();
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Features/Identity/Authenticate.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Features/Identity/Authenticate.cs
@@ -1,0 +1,72 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Identity.Core;
+using WeddingBidders.Identity.Core.Services;
+
+namespace WeddingBidders.Identity.Api.Features.Identity;
+
+public class AuthenticateRequest : IRequest<AuthenticateResponse>
+{
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}
+
+public class AuthenticateResponse
+{
+    public Guid UserId { get; set; }
+    public string Token { get; set; } = string.Empty;
+}
+
+public class AuthenticateRequestValidator : AbstractValidator<AuthenticateRequest>
+{
+    public AuthenticateRequestValidator()
+    {
+        RuleFor(x => x.Username).NotEmpty().WithMessage("Username is required");
+        RuleFor(x => x.Password).NotEmpty().WithMessage("Password is required");
+    }
+}
+
+public class AuthenticateHandler : IRequestHandler<AuthenticateRequest, AuthenticateResponse>
+{
+    private readonly IIdentityContext _context;
+    private readonly IPasswordHasher _passwordHasher;
+    private readonly ITokenService _tokenService;
+
+    public AuthenticateHandler(
+        IIdentityContext context,
+        IPasswordHasher passwordHasher,
+        ITokenService tokenService)
+    {
+        _context = context;
+        _passwordHasher = passwordHasher;
+        _tokenService = tokenService;
+    }
+
+    public async Task<AuthenticateResponse> Handle(AuthenticateRequest request, CancellationToken cancellationToken)
+    {
+        var user = await _context.Users
+            .Include(u => u.Roles)
+            .ThenInclude(r => r.Privileges)
+            .FirstOrDefaultAsync(u => u.Username == request.Username, cancellationToken);
+
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException("Invalid username or password");
+        }
+
+        var isValidPassword = _passwordHasher.VerifyPassword(request.Password, user.Password, user.Salt);
+        if (!isValidPassword)
+        {
+            throw new UnauthorizedAccessException("Invalid username or password");
+        }
+
+        var token = _tokenService.GenerateToken(user);
+
+        return new AuthenticateResponse
+        {
+            UserId = user.UserId,
+            Token = token
+        };
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Features/Identity/GetCurrentUser.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Features/Identity/GetCurrentUser.cs
@@ -1,0 +1,39 @@
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Identity.Api.Features.Users;
+using WeddingBidders.Identity.Core;
+
+namespace WeddingBidders.Identity.Api.Features.Identity;
+
+public class GetCurrentUserRequest : IRequest<UserDto?>
+{
+}
+
+public class GetCurrentUserHandler : IRequestHandler<GetCurrentUserRequest, UserDto?>
+{
+    private readonly IIdentityContext _context;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public GetCurrentUserHandler(IIdentityContext context, IHttpContextAccessor httpContextAccessor)
+    {
+        _context = context;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<UserDto?> Handle(GetCurrentUserRequest request, CancellationToken cancellationToken)
+    {
+        var username = _httpContextAccessor.HttpContext?.User.Identity?.Name;
+        if (string.IsNullOrEmpty(username))
+        {
+            return null;
+        }
+
+        var user = await _context.Users
+            .Include(u => u.Roles)
+            .ThenInclude(r => r.Privileges)
+            .FirstOrDefaultAsync(u => u.Username == username, cancellationToken);
+
+        return user?.ToDto();
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Features/Profiles/CreateProfile.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Features/Profiles/CreateProfile.cs
@@ -1,0 +1,77 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Identity.Core;
+using WeddingBidders.Identity.Core.Model;
+using WeddingBidders.Shared.Core.Events;
+using WeddingBidders.Shared.Messaging;
+
+namespace WeddingBidders.Identity.Api.Features.Profiles;
+
+public class CreateProfileRequest : IRequest<ProfileDto>
+{
+    public Guid UserId { get; set; }
+    public Guid AccountId { get; set; }
+    public ProfileType ProfileType { get; set; }
+}
+
+public class CreateProfileRequestValidator : AbstractValidator<CreateProfileRequest>
+{
+    public CreateProfileRequestValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty();
+        RuleFor(x => x.AccountId).NotEmpty();
+    }
+}
+
+public class CreateProfileHandler : IRequestHandler<CreateProfileRequest, ProfileDto>
+{
+    private readonly IIdentityContext _context;
+    private readonly IEventBus _eventBus;
+
+    public CreateProfileHandler(IIdentityContext context, IEventBus eventBus)
+    {
+        _context = context;
+        _eventBus = eventBus;
+    }
+
+    public async Task<ProfileDto> Handle(CreateProfileRequest request, CancellationToken cancellationToken)
+    {
+        var user = await _context.Users
+            .FirstOrDefaultAsync(u => u.UserId == request.UserId, cancellationToken);
+
+        if (user == null)
+        {
+            throw new InvalidOperationException("User not found");
+        }
+
+        var profile = new Profile
+        {
+            ProfileId = Guid.NewGuid(),
+            UserId = request.UserId,
+            AccountId = request.AccountId,
+            ProfileType = request.ProfileType,
+            IsPersonalized = false,
+            CreatedDate = DateTime.UtcNow
+        };
+
+        _context.Profiles.Add(profile);
+
+        if (!user.DefaultProfileId.HasValue)
+        {
+            user.DefaultProfileId = profile.ProfileId;
+            user.CurrentProfileId = profile.ProfileId;
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await _eventBus.PublishAsync(new ProfileCreatedEvent
+        {
+            ProfileId = profile.ProfileId,
+            UserId = profile.UserId,
+            ProfileType = profile.ProfileType.ToString()
+        }, cancellationToken);
+
+        return profile.ToDto();
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Features/Profiles/GetCurrentProfile.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Features/Profiles/GetCurrentProfile.cs
@@ -1,0 +1,36 @@
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Identity.Core;
+
+namespace WeddingBidders.Identity.Api.Features.Profiles;
+
+public class GetCurrentProfileRequest : IRequest<ProfileDto?>
+{
+}
+
+public class GetCurrentProfileHandler : IRequestHandler<GetCurrentProfileRequest, ProfileDto?>
+{
+    private readonly IIdentityContext _context;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public GetCurrentProfileHandler(IIdentityContext context, IHttpContextAccessor httpContextAccessor)
+    {
+        _context = context;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<ProfileDto?> Handle(GetCurrentProfileRequest request, CancellationToken cancellationToken)
+    {
+        var currentProfileIdClaim = _httpContextAccessor.HttpContext?.User.FindFirst("CurrentProfileId")?.Value;
+        if (string.IsNullOrEmpty(currentProfileIdClaim) || !Guid.TryParse(currentProfileIdClaim, out var profileId))
+        {
+            return null;
+        }
+
+        var profile = await _context.Profiles
+            .FirstOrDefaultAsync(p => p.ProfileId == profileId, cancellationToken);
+
+        return profile?.ToDto();
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Features/Profiles/GetProfileById.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Features/Profiles/GetProfileById.cs
@@ -1,0 +1,28 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Identity.Core;
+
+namespace WeddingBidders.Identity.Api.Features.Profiles;
+
+public class GetProfileByIdRequest : IRequest<ProfileDto?>
+{
+    public Guid ProfileId { get; set; }
+}
+
+public class GetProfileByIdHandler : IRequestHandler<GetProfileByIdRequest, ProfileDto?>
+{
+    private readonly IIdentityContext _context;
+
+    public GetProfileByIdHandler(IIdentityContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<ProfileDto?> Handle(GetProfileByIdRequest request, CancellationToken cancellationToken)
+    {
+        var profile = await _context.Profiles
+            .FirstOrDefaultAsync(p => p.ProfileId == request.ProfileId, cancellationToken);
+
+        return profile?.ToDto();
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Features/Profiles/ProfileDto.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Features/Profiles/ProfileDto.cs
@@ -1,0 +1,27 @@
+using WeddingBidders.Identity.Core.Model;
+
+namespace WeddingBidders.Identity.Api.Features.Profiles;
+
+public class ProfileDto
+{
+    public Guid ProfileId { get; set; }
+    public Guid UserId { get; set; }
+    public Guid AccountId { get; set; }
+    public string ProfileType { get; set; } = string.Empty;
+    public bool IsPersonalized { get; set; }
+}
+
+public static class ProfileExtensions
+{
+    public static ProfileDto ToDto(this Profile profile)
+    {
+        return new ProfileDto
+        {
+            ProfileId = profile.ProfileId,
+            UserId = profile.UserId,
+            AccountId = profile.AccountId,
+            ProfileType = profile.ProfileType.ToString(),
+            IsPersonalized = profile.IsPersonalized
+        };
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Features/Users/CreateUser.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Features/Users/CreateUser.cs
@@ -1,0 +1,76 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Identity.Core;
+using WeddingBidders.Identity.Core.Model;
+using WeddingBidders.Identity.Core.Services;
+using WeddingBidders.Shared.Core.Events;
+using WeddingBidders.Shared.Messaging;
+
+namespace WeddingBidders.Identity.Api.Features.Users;
+
+public class CreateUserRequest : IRequest<UserDto>
+{
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}
+
+public class CreateUserRequestValidator : AbstractValidator<CreateUserRequest>
+{
+    public CreateUserRequestValidator()
+    {
+        RuleFor(x => x.Username).NotEmpty().EmailAddress();
+        RuleFor(x => x.Password).NotEmpty().MinimumLength(6);
+    }
+}
+
+public class CreateUserHandler : IRequestHandler<CreateUserRequest, UserDto>
+{
+    private readonly IIdentityContext _context;
+    private readonly IPasswordHasher _passwordHasher;
+    private readonly IEventBus _eventBus;
+
+    public CreateUserHandler(IIdentityContext context, IPasswordHasher passwordHasher, IEventBus eventBus)
+    {
+        _context = context;
+        _passwordHasher = passwordHasher;
+        _eventBus = eventBus;
+    }
+
+    public async Task<UserDto> Handle(CreateUserRequest request, CancellationToken cancellationToken)
+    {
+        var usernameExists = await _context.Users
+            .AnyAsync(u => u.Username.ToLower() == request.Username.ToLower(), cancellationToken);
+
+        if (usernameExists)
+        {
+            throw new InvalidOperationException("Username already exists");
+        }
+
+        var memberRole = await _context.Roles
+            .FirstOrDefaultAsync(r => r.Name == "Member", cancellationToken);
+
+        var salt = _passwordHasher.GenerateSalt();
+        var hashedPassword = _passwordHasher.HashPassword(request.Password, salt);
+
+        var user = new User
+        {
+            UserId = Guid.NewGuid(),
+            Username = request.Username,
+            Password = hashedPassword,
+            Salt = salt,
+            Roles = memberRole != null ? new List<Role> { memberRole } : new List<Role>()
+        };
+
+        _context.Users.Add(user);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await _eventBus.PublishAsync(new UserCreatedEvent
+        {
+            UserId = user.UserId,
+            Username = user.Username
+        }, cancellationToken);
+
+        return user.ToDto();
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Features/Users/DeleteUser.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Features/Users/DeleteUser.cs
@@ -1,0 +1,45 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Identity.Core;
+using WeddingBidders.Shared.Core.Events;
+using WeddingBidders.Shared.Messaging;
+
+namespace WeddingBidders.Identity.Api.Features.Users;
+
+public class DeleteUserRequest : IRequest<bool>
+{
+    public Guid UserId { get; set; }
+}
+
+public class DeleteUserHandler : IRequestHandler<DeleteUserRequest, bool>
+{
+    private readonly IIdentityContext _context;
+    private readonly IEventBus _eventBus;
+
+    public DeleteUserHandler(IIdentityContext context, IEventBus eventBus)
+    {
+        _context = context;
+        _eventBus = eventBus;
+    }
+
+    public async Task<bool> Handle(DeleteUserRequest request, CancellationToken cancellationToken)
+    {
+        var user = await _context.Users
+            .FirstOrDefaultAsync(u => u.UserId == request.UserId, cancellationToken);
+
+        if (user == null)
+        {
+            return false;
+        }
+
+        user.IsDeleted = true;
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await _eventBus.PublishAsync(new UserDeletedEvent
+        {
+            UserId = user.UserId
+        }, cancellationToken);
+
+        return true;
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Features/Users/GetUserById.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Features/Users/GetUserById.cs
@@ -1,0 +1,29 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Identity.Core;
+
+namespace WeddingBidders.Identity.Api.Features.Users;
+
+public class GetUserByIdRequest : IRequest<UserDto?>
+{
+    public Guid UserId { get; set; }
+}
+
+public class GetUserByIdHandler : IRequestHandler<GetUserByIdRequest, UserDto?>
+{
+    private readonly IIdentityContext _context;
+
+    public GetUserByIdHandler(IIdentityContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<UserDto?> Handle(GetUserByIdRequest request, CancellationToken cancellationToken)
+    {
+        var user = await _context.Users
+            .Include(u => u.Roles)
+            .FirstOrDefaultAsync(u => u.UserId == request.UserId, cancellationToken);
+
+        return user?.ToDto();
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Features/Users/UserDto.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Features/Users/UserDto.cs
@@ -1,0 +1,27 @@
+using WeddingBidders.Identity.Core.Model;
+
+namespace WeddingBidders.Identity.Api.Features.Users;
+
+public class UserDto
+{
+    public Guid UserId { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public Guid? CurrentProfileId { get; set; }
+    public Guid? DefaultProfileId { get; set; }
+    public List<string> Roles { get; set; } = new();
+}
+
+public static class UserExtensions
+{
+    public static UserDto ToDto(this User user)
+    {
+        return new UserDto
+        {
+            UserId = user.UserId,
+            Username = user.Username,
+            CurrentProfileId = user.CurrentProfileId,
+            DefaultProfileId = user.DefaultProfileId,
+            Roles = user.Roles.Select(r => r.Name).ToList()
+        };
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Api/Program.cs
+++ b/services/identity/WeddingBidders.Identity.Api/Program.cs
@@ -1,0 +1,167 @@
+using System.Text;
+using FluentValidation;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using Serilog;
+using WeddingBidders.Identity.Api.Behaviours;
+using WeddingBidders.Identity.Core;
+using WeddingBidders.Identity.Core.Services;
+using WeddingBidders.Identity.Infrastructure;
+using WeddingBidders.Identity.Infrastructure.Seeding;
+using WeddingBidders.Shared.Messaging;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Configure Serilog
+Log.Logger = new LoggerConfiguration()
+    .ReadFrom.Configuration(builder.Configuration)
+    .Enrich.FromLogContext()
+    .WriteTo.Console()
+    .CreateLogger();
+
+builder.Host.UseSerilog();
+
+// Add services to the container
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Identity Service API", Version = "v1" });
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Description = "JWT Authorization header using the Bearer scheme",
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = "Bearer"
+    });
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+});
+
+// Database - Identity Service has its own database
+builder.Services.AddDbContext<IdentityContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("IdentityConnection")));
+builder.Services.AddScoped<IIdentityContext>(sp => sp.GetRequiredService<IdentityContext>());
+
+// Services
+builder.Services.AddSingleton<IPasswordHasher, PasswordHasher>();
+builder.Services.AddSingleton<ITokenService>(sp =>
+{
+    var config = builder.Configuration;
+    return new TokenService(
+        config["Jwt:SecretKey"]!,
+        config["Jwt:Issuer"]!,
+        config["Jwt:Audience"]!,
+        int.Parse(config["Jwt:ExpirationMinutes"]!)
+    );
+});
+builder.Services.AddScoped<IdentitySeedingService>();
+
+// Redis Event Bus with MessagePack serialization
+builder.Services.AddRedisEventBus(builder.Configuration.GetConnectionString("Redis")!);
+
+// MediatR
+builder.Services.AddMediatR(cfg =>
+{
+    cfg.RegisterServicesFromAssembly(typeof(Program).Assembly);
+    cfg.AddOpenBehavior(typeof(LoggingBehavior<,>));
+    cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
+});
+
+// FluentValidation
+builder.Services.AddValidatorsFromAssembly(typeof(Program).Assembly);
+
+// Authorization
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddAuthorization();
+
+// JWT Authentication
+var jwtKey = builder.Configuration["Jwt:SecretKey"]!;
+var jwtIssuer = builder.Configuration["Jwt:Issuer"]!;
+var jwtAudience = builder.Configuration["Jwt:Audience"]!;
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddJwtBearer(options =>
+{
+    options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
+    options.SaveToken = true;
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey)),
+        ValidateIssuer = true,
+        ValidIssuer = jwtIssuer,
+        ValidateAudience = true,
+        ValidAudience = jwtAudience,
+        ValidateLifetime = true,
+        ClockSkew = TimeSpan.Zero
+    };
+});
+
+// CORS
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("CorsPolicy", policy =>
+    {
+        var origins = builder.Configuration["Cors:Origins"]?.Split(',') ?? Array.Empty<string>();
+        policy.WithOrigins(origins)
+            .AllowAnyMethod()
+            .AllowAnyHeader()
+            .AllowCredentials();
+    });
+});
+
+var app = builder.Build();
+
+// Seed database
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider.GetRequiredService<IdentityContext>();
+
+    if (app.Environment.IsDevelopment())
+    {
+        await context.Database.EnsureCreatedAsync();
+        var seeder = scope.ServiceProvider.GetRequiredService<IdentitySeedingService>();
+        await seeder.SeedAsync();
+    }
+}
+
+// Configure the HTTP request pipeline
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseCors("CorsPolicy");
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.UseSerilogRequestLogging();
+
+app.MapControllers();
+
+app.Run();
+
+public partial class Program { }

--- a/services/identity/WeddingBidders.Identity.Api/WeddingBidders.Identity.Api.csproj
+++ b/services/identity/WeddingBidders.Identity.Api/WeddingBidders.Identity.Api.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="MediatR" Version="12.2.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WeddingBidders.Identity.Core\WeddingBidders.Identity.Core.csproj" />
+    <ProjectReference Include="..\WeddingBidders.Identity.Infrastructure\WeddingBidders.Identity.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\shared\WeddingBidders.Shared.Messaging\WeddingBidders.Shared.Messaging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/identity/WeddingBidders.Identity.Api/appsettings.json
+++ b/services/identity/WeddingBidders.Identity.Api/appsettings.json
@@ -1,0 +1,48 @@
+{
+  "Serilog": {
+    "Using": ["Serilog.Sinks.Console", "Serilog.Sinks.File"],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning",
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}"
+        }
+      },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "logs/identity-service-.log",
+          "rollingInterval": "Day",
+          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {CorrelationId} {UserId} {Message:lj}{NewLine}{Exception}"
+        }
+      }
+    ],
+    "Enrich": ["FromLogContext", "WithMachineName", "WithEnvironmentName"],
+    "Properties": {
+      "Application": "IdentityService"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "IdentityConnection": "Server=localhost;Database=WeddingBidders_Identity;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True",
+    "Redis": "localhost:6379"
+  },
+  "Jwt": {
+    "SecretKey": "WeddingBiddersSecretKeyForJwtTokenGenerationMustBe32CharsLong!",
+    "Issuer": "localhost",
+    "Audience": "all",
+    "ExpirationMinutes": 10080
+  },
+  "Cors": {
+    "Origins": "http://localhost:4200"
+  }
+}

--- a/services/identity/WeddingBidders.Identity.Core/IIdentityContext.cs
+++ b/services/identity/WeddingBidders.Identity.Core/IIdentityContext.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Identity.Core.Model;
+
+namespace WeddingBidders.Identity.Core;
+
+public interface IIdentityContext
+{
+    DbSet<User> Users { get; }
+    DbSet<Role> Roles { get; }
+    DbSet<Privilege> Privileges { get; }
+    DbSet<Profile> Profiles { get; }
+    DbSet<Account> Accounts { get; }
+    DbSet<InvitationToken> InvitationTokens { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/services/identity/WeddingBidders.Identity.Core/Model/Account.cs
+++ b/services/identity/WeddingBidders.Identity.Core/Model/Account.cs
@@ -1,0 +1,26 @@
+using WeddingBidders.Shared.Core;
+
+namespace WeddingBidders.Identity.Core.Model;
+
+public class Account : BaseEntity
+{
+    public Guid AccountId { get; set; }
+    public AccountType AccountType { get; set; }
+    public AccountStatus AccountStatus { get; set; }
+    public Guid UserId { get; set; }
+    public User? User { get; set; }
+    public ICollection<Profile> Profiles { get; set; } = new List<Profile>();
+}
+
+public enum AccountType
+{
+    Customer = 0,
+    Bidder = 1
+}
+
+public enum AccountStatus
+{
+    Active = 0,
+    Inactive = 1,
+    Suspended = 2
+}

--- a/services/identity/WeddingBidders.Identity.Core/Model/InvitationToken.cs
+++ b/services/identity/WeddingBidders.Identity.Core/Model/InvitationToken.cs
@@ -1,0 +1,18 @@
+using WeddingBidders.Shared.Core;
+
+namespace WeddingBidders.Identity.Core.Model;
+
+public class InvitationToken : BaseEntity
+{
+    public Guid InvitationTokenId { get; set; }
+    public string Token { get; set; } = string.Empty;
+    public InvitationTokenType Type { get; set; }
+    public bool IsUsed { get; set; }
+    public DateTime ExpiryDate { get; set; }
+}
+
+public enum InvitationTokenType
+{
+    Registration = 0,
+    PasswordReset = 1
+}

--- a/services/identity/WeddingBidders.Identity.Core/Model/Privilege.cs
+++ b/services/identity/WeddingBidders.Identity.Core/Model/Privilege.cs
@@ -1,0 +1,18 @@
+namespace WeddingBidders.Identity.Core.Model;
+
+public class Privilege
+{
+    public Guid PrivilegeId { get; set; }
+    public string Aggregate { get; set; } = string.Empty;
+    public AccessRight AccessRight { get; set; }
+    public Guid RoleId { get; set; }
+    public Role? Role { get; set; }
+}
+
+public enum AccessRight
+{
+    Read = 0,
+    Write = 1,
+    Create = 2,
+    Delete = 3
+}

--- a/services/identity/WeddingBidders.Identity.Core/Model/Profile.cs
+++ b/services/identity/WeddingBidders.Identity.Core/Model/Profile.cs
@@ -1,0 +1,20 @@
+using WeddingBidders.Shared.Core;
+
+namespace WeddingBidders.Identity.Core.Model;
+
+public class Profile : BaseEntity
+{
+    public Guid ProfileId { get; set; }
+    public Guid UserId { get; set; }
+    public User? User { get; set; }
+    public Guid AccountId { get; set; }
+    public Account? Account { get; set; }
+    public ProfileType ProfileType { get; set; }
+    public bool IsPersonalized { get; set; }
+}
+
+public enum ProfileType
+{
+    Customer = 0,
+    Bidder = 1
+}

--- a/services/identity/WeddingBidders.Identity.Core/Model/Role.cs
+++ b/services/identity/WeddingBidders.Identity.Core/Model/Role.cs
@@ -1,0 +1,11 @@
+using WeddingBidders.Shared.Core;
+
+namespace WeddingBidders.Identity.Core.Model;
+
+public class Role : BaseEntity
+{
+    public Guid RoleId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public ICollection<Privilege> Privileges { get; set; } = new List<Privilege>();
+    public ICollection<User> Users { get; set; } = new List<User>();
+}

--- a/services/identity/WeddingBidders.Identity.Core/Model/User.cs
+++ b/services/identity/WeddingBidders.Identity.Core/Model/User.cs
@@ -1,0 +1,15 @@
+using WeddingBidders.Shared.Core;
+
+namespace WeddingBidders.Identity.Core.Model;
+
+public class User : BaseEntity
+{
+    public Guid UserId { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+    public byte[] Salt { get; set; } = Array.Empty<byte>();
+    public Guid? CurrentProfileId { get; set; }
+    public Guid? DefaultProfileId { get; set; }
+    public ICollection<Role> Roles { get; set; } = new List<Role>();
+    public ICollection<Profile> Profiles { get; set; } = new List<Profile>();
+}

--- a/services/identity/WeddingBidders.Identity.Core/Services/IPasswordHasher.cs
+++ b/services/identity/WeddingBidders.Identity.Core/Services/IPasswordHasher.cs
@@ -1,0 +1,8 @@
+namespace WeddingBidders.Identity.Core.Services;
+
+public interface IPasswordHasher
+{
+    byte[] GenerateSalt();
+    string HashPassword(string password, byte[] salt);
+    bool VerifyPassword(string password, string hash, byte[] salt);
+}

--- a/services/identity/WeddingBidders.Identity.Core/Services/ITokenService.cs
+++ b/services/identity/WeddingBidders.Identity.Core/Services/ITokenService.cs
@@ -1,0 +1,8 @@
+using WeddingBidders.Identity.Core.Model;
+
+namespace WeddingBidders.Identity.Core.Services;
+
+public interface ITokenService
+{
+    string GenerateToken(User user);
+}

--- a/services/identity/WeddingBidders.Identity.Core/Services/PasswordHasher.cs
+++ b/services/identity/WeddingBidders.Identity.Core/Services/PasswordHasher.cs
@@ -1,0 +1,36 @@
+using System.Security.Cryptography;
+
+namespace WeddingBidders.Identity.Core.Services;
+
+public class PasswordHasher : IPasswordHasher
+{
+    private const int SaltSize = 16;
+    private const int KeySize = 32;
+    private const int Iterations = 100000;
+    private static readonly HashAlgorithmName Algorithm = HashAlgorithmName.SHA256;
+
+    public byte[] GenerateSalt()
+    {
+        return RandomNumberGenerator.GetBytes(SaltSize);
+    }
+
+    public string HashPassword(string password, byte[] salt)
+    {
+        var hash = Rfc2898DeriveBytes.Pbkdf2(
+            password,
+            salt,
+            Iterations,
+            Algorithm,
+            KeySize);
+
+        return Convert.ToBase64String(hash);
+    }
+
+    public bool VerifyPassword(string password, string hash, byte[] salt)
+    {
+        var hashToCompare = HashPassword(password, salt);
+        return CryptographicOperations.FixedTimeEquals(
+            Convert.FromBase64String(hash),
+            Convert.FromBase64String(hashToCompare));
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Core/Services/TokenService.cs
+++ b/services/identity/WeddingBidders.Identity.Core/Services/TokenService.cs
@@ -1,0 +1,60 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+using WeddingBidders.Identity.Core.Model;
+
+namespace WeddingBidders.Identity.Core.Services;
+
+public class TokenService : ITokenService
+{
+    private readonly string _secretKey;
+    private readonly string _issuer;
+    private readonly string _audience;
+    private readonly int _expirationMinutes;
+
+    public TokenService(string secretKey, string issuer, string audience, int expirationMinutes)
+    {
+        _secretKey = secretKey;
+        _issuer = issuer;
+        _audience = audience;
+        _expirationMinutes = expirationMinutes;
+    }
+
+    public string GenerateToken(User user)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, user.UserId.ToString()),
+            new(ClaimTypes.Name, user.Username),
+            new("UserId", user.UserId.ToString())
+        };
+
+        if (user.CurrentProfileId.HasValue)
+        {
+            claims.Add(new Claim("CurrentProfileId", user.CurrentProfileId.Value.ToString()));
+        }
+
+        foreach (var role in user.Roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role.Name));
+
+            foreach (var privilege in role.Privileges)
+            {
+                claims.Add(new Claim("Privilege", $"{privilege.Aggregate}:{privilege.AccessRight}"));
+            }
+        }
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_secretKey));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: _issuer,
+            audience: _audience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(_expirationMinutes),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Core/WeddingBidders.Identity.Core.csproj
+++ b/services/identity/WeddingBidders.Identity.Core/WeddingBidders.Identity.Core.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\shared\WeddingBidders.Shared.Core\WeddingBidders.Shared.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/identity/WeddingBidders.Identity.Infrastructure/Configurations/AccountConfiguration.cs
+++ b/services/identity/WeddingBidders.Identity.Infrastructure/Configurations/AccountConfiguration.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WeddingBidders.Identity.Core.Model;
+
+namespace WeddingBidders.Identity.Infrastructure.Configurations;
+
+public class AccountConfiguration : IEntityTypeConfiguration<Account>
+{
+    public void Configure(EntityTypeBuilder<Account> builder)
+    {
+        builder.HasKey(a => a.AccountId);
+        builder.HasQueryFilter(a => !a.IsDeleted);
+
+        builder.HasMany(a => a.Profiles)
+            .WithOne(p => p.Account)
+            .HasForeignKey(p => p.AccountId);
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Infrastructure/Configurations/InvitationTokenConfiguration.cs
+++ b/services/identity/WeddingBidders.Identity.Infrastructure/Configurations/InvitationTokenConfiguration.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WeddingBidders.Identity.Core.Model;
+
+namespace WeddingBidders.Identity.Infrastructure.Configurations;
+
+public class InvitationTokenConfiguration : IEntityTypeConfiguration<InvitationToken>
+{
+    public void Configure(EntityTypeBuilder<InvitationToken> builder)
+    {
+        builder.HasKey(t => t.InvitationTokenId);
+        builder.Property(t => t.Token).IsRequired().HasMaxLength(255);
+        builder.HasIndex(t => t.Token).IsUnique();
+        builder.HasQueryFilter(t => !t.IsDeleted);
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Infrastructure/Configurations/PrivilegeConfiguration.cs
+++ b/services/identity/WeddingBidders.Identity.Infrastructure/Configurations/PrivilegeConfiguration.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WeddingBidders.Identity.Core.Model;
+
+namespace WeddingBidders.Identity.Infrastructure.Configurations;
+
+public class PrivilegeConfiguration : IEntityTypeConfiguration<Privilege>
+{
+    public void Configure(EntityTypeBuilder<Privilege> builder)
+    {
+        builder.HasKey(p => p.PrivilegeId);
+        builder.Property(p => p.Aggregate).IsRequired().HasMaxLength(100);
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Infrastructure/Configurations/ProfileConfiguration.cs
+++ b/services/identity/WeddingBidders.Identity.Infrastructure/Configurations/ProfileConfiguration.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WeddingBidders.Identity.Core.Model;
+
+namespace WeddingBidders.Identity.Infrastructure.Configurations;
+
+public class ProfileConfiguration : IEntityTypeConfiguration<Profile>
+{
+    public void Configure(EntityTypeBuilder<Profile> builder)
+    {
+        builder.HasKey(p => p.ProfileId);
+        builder.HasQueryFilter(p => !p.IsDeleted);
+
+        builder.HasOne(p => p.User)
+            .WithMany(u => u.Profiles)
+            .HasForeignKey(p => p.UserId);
+
+        builder.HasOne(p => p.Account)
+            .WithMany(a => a.Profiles)
+            .HasForeignKey(p => p.AccountId);
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Infrastructure/Configurations/RoleConfiguration.cs
+++ b/services/identity/WeddingBidders.Identity.Infrastructure/Configurations/RoleConfiguration.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WeddingBidders.Identity.Core.Model;
+
+namespace WeddingBidders.Identity.Infrastructure.Configurations;
+
+public class RoleConfiguration : IEntityTypeConfiguration<Role>
+{
+    public void Configure(EntityTypeBuilder<Role> builder)
+    {
+        builder.HasKey(r => r.RoleId);
+        builder.Property(r => r.Name).IsRequired().HasMaxLength(100);
+        builder.HasIndex(r => r.Name).IsUnique();
+        builder.HasQueryFilter(r => !r.IsDeleted);
+
+        builder.HasMany(r => r.Privileges)
+            .WithOne(p => p.Role)
+            .HasForeignKey(p => p.RoleId);
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Infrastructure/Configurations/UserConfiguration.cs
+++ b/services/identity/WeddingBidders.Identity.Infrastructure/Configurations/UserConfiguration.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WeddingBidders.Identity.Core.Model;
+
+namespace WeddingBidders.Identity.Infrastructure.Configurations;
+
+public class UserConfiguration : IEntityTypeConfiguration<User>
+{
+    public void Configure(EntityTypeBuilder<User> builder)
+    {
+        builder.HasKey(u => u.UserId);
+        builder.Property(u => u.Username).IsRequired().HasMaxLength(255);
+        builder.Property(u => u.Password).IsRequired().HasMaxLength(255);
+        builder.HasIndex(u => u.Username).IsUnique();
+        builder.HasQueryFilter(u => !u.IsDeleted);
+
+        builder.HasMany(u => u.Roles)
+            .WithMany(r => r.Users)
+            .UsingEntity(j => j.ToTable("UserRoles"));
+
+        builder.HasMany(u => u.Profiles)
+            .WithOne(p => p.User)
+            .HasForeignKey(p => p.UserId);
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Infrastructure/IdentityContext.cs
+++ b/services/identity/WeddingBidders.Identity.Infrastructure/IdentityContext.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Identity.Core;
+using WeddingBidders.Identity.Core.Model;
+
+namespace WeddingBidders.Identity.Infrastructure;
+
+public class IdentityContext : DbContext, IIdentityContext
+{
+    public IdentityContext(DbContextOptions<IdentityContext> options) : base(options)
+    {
+    }
+
+    public DbSet<User> Users => Set<User>();
+    public DbSet<Role> Roles => Set<Role>();
+    public DbSet<Privilege> Privileges => Set<Privilege>();
+    public DbSet<Profile> Profiles => Set<Profile>();
+    public DbSet<Account> Accounts => Set<Account>();
+    public DbSet<InvitationToken> InvitationTokens => Set<InvitationToken>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(IdentityContext).Assembly);
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Infrastructure/Seeding/IdentitySeedingService.cs
+++ b/services/identity/WeddingBidders.Identity.Infrastructure/Seeding/IdentitySeedingService.cs
@@ -1,0 +1,102 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Identity.Core;
+using WeddingBidders.Identity.Core.Model;
+using WeddingBidders.Identity.Core.Services;
+
+namespace WeddingBidders.Identity.Infrastructure.Seeding;
+
+public class IdentitySeedingService
+{
+    private readonly IIdentityContext _context;
+    private readonly IPasswordHasher _passwordHasher;
+
+    public IdentitySeedingService(IIdentityContext context, IPasswordHasher passwordHasher)
+    {
+        _context = context;
+        _passwordHasher = passwordHasher;
+    }
+
+    public async Task SeedAsync()
+    {
+        await SeedRolesAsync();
+        await SeedUsersAsync();
+        await _context.SaveChangesAsync();
+    }
+
+    private async Task SeedRolesAsync()
+    {
+        if (await _context.Roles.AnyAsync())
+            return;
+
+        var systemAdminRole = new Role
+        {
+            RoleId = Guid.Parse("00000000-0000-0000-0000-000000000001"),
+            Name = "SystemAdministrator",
+            Privileges = CreateSystemAdminPrivileges()
+        };
+
+        var memberRole = new Role
+        {
+            RoleId = Guid.Parse("00000000-0000-0000-0000-000000000002"),
+            Name = "Member",
+            Privileges = CreateMemberPrivileges()
+        };
+
+        _context.Roles.Add(systemAdminRole);
+        _context.Roles.Add(memberRole);
+    }
+
+    private static List<Privilege> CreateSystemAdminPrivileges()
+    {
+        var aggregates = new[] { "User", "Role", "Profile", "InvitationToken", "Account" };
+        var accessRights = new[] { AccessRight.Read, AccessRight.Write, AccessRight.Create, AccessRight.Delete };
+        var privileges = new List<Privilege>();
+
+        foreach (var aggregate in aggregates)
+        {
+            foreach (var accessRight in accessRights)
+            {
+                privileges.Add(new Privilege
+                {
+                    PrivilegeId = Guid.NewGuid(),
+                    Aggregate = aggregate,
+                    AccessRight = accessRight
+                });
+            }
+        }
+
+        return privileges;
+    }
+
+    private static List<Privilege> CreateMemberPrivileges()
+    {
+        return new List<Privilege>
+        {
+            new() { PrivilegeId = Guid.NewGuid(), Aggregate = "Profile", AccessRight = AccessRight.Read },
+            new() { PrivilegeId = Guid.NewGuid(), Aggregate = "Profile", AccessRight = AccessRight.Write }
+        };
+    }
+
+    private async Task SeedUsersAsync()
+    {
+        if (await _context.Users.AnyAsync())
+            return;
+
+        var adminRole = await _context.Roles.FirstOrDefaultAsync(r => r.Name == "SystemAdministrator");
+        if (adminRole == null) return;
+
+        var salt = _passwordHasher.GenerateSalt();
+        var hashedPassword = _passwordHasher.HashPassword("Admin123!", salt);
+
+        var adminUser = new User
+        {
+            UserId = Guid.Parse("00000000-0000-0000-0000-000000000001"),
+            Username = "admin@weddingbidders.com",
+            Password = hashedPassword,
+            Salt = salt,
+            Roles = new List<Role> { adminRole }
+        };
+
+        _context.Users.Add(adminUser);
+    }
+}

--- a/services/identity/WeddingBidders.Identity.Infrastructure/WeddingBidders.Identity.Infrastructure.csproj
+++ b/services/identity/WeddingBidders.Identity.Infrastructure/WeddingBidders.Identity.Infrastructure.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WeddingBidders.Identity.Core\WeddingBidders.Identity.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/messaging/WeddingBidders.Messaging.Api/Controllers/MessagesController.cs
+++ b/services/messaging/WeddingBidders.Messaging.Api/Controllers/MessagesController.cs
@@ -1,0 +1,33 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using WeddingBidders.Messaging.Api.Features.Messages;
+
+namespace WeddingBidders.Messaging.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class MessagesController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public MessagesController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<MessageDto>> SendMessage([FromBody] SendMessageRequest request)
+    {
+        var message = await _mediator.Send(request);
+        return CreatedAtAction(nameof(GetConversations), message);
+    }
+
+    [HttpGet("conversations/{profileId:guid}")]
+    public async Task<ActionResult<List<ConversationDto>>> GetConversations(Guid profileId)
+    {
+        var conversations = await _mediator.Send(new GetConversationsRequest { ProfileId = profileId });
+        return Ok(conversations);
+    }
+}

--- a/services/messaging/WeddingBidders.Messaging.Api/Dockerfile
+++ b/services/messaging/WeddingBidders.Messaging.Api/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["shared/WeddingBidders.Shared.Core/WeddingBidders.Shared.Core.csproj", "shared/WeddingBidders.Shared.Core/"]
+COPY ["shared/WeddingBidders.Shared.Messaging/WeddingBidders.Shared.Messaging.csproj", "shared/WeddingBidders.Shared.Messaging/"]
+COPY ["messaging/WeddingBidders.Messaging.Core/WeddingBidders.Messaging.Core.csproj", "messaging/WeddingBidders.Messaging.Core/"]
+COPY ["messaging/WeddingBidders.Messaging.Infrastructure/WeddingBidders.Messaging.Infrastructure.csproj", "messaging/WeddingBidders.Messaging.Infrastructure/"]
+COPY ["messaging/WeddingBidders.Messaging.Api/WeddingBidders.Messaging.Api.csproj", "messaging/WeddingBidders.Messaging.Api/"]
+RUN dotnet restore "messaging/WeddingBidders.Messaging.Api/WeddingBidders.Messaging.Api.csproj"
+COPY . .
+WORKDIR "/src/messaging/WeddingBidders.Messaging.Api"
+RUN dotnet build "WeddingBidders.Messaging.Api.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "WeddingBidders.Messaging.Api.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "WeddingBidders.Messaging.Api.dll"]

--- a/services/messaging/WeddingBidders.Messaging.Api/Features/Messages/GetConversations.cs
+++ b/services/messaging/WeddingBidders.Messaging.Api/Features/Messages/GetConversations.cs
@@ -1,0 +1,31 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Messaging.Core;
+
+namespace WeddingBidders.Messaging.Api.Features.Messages;
+
+public class GetConversationsRequest : IRequest<List<ConversationDto>>
+{
+    public Guid ProfileId { get; set; }
+}
+
+public class GetConversationsHandler : IRequestHandler<GetConversationsRequest, List<ConversationDto>>
+{
+    private readonly IMessagingContext _context;
+
+    public GetConversationsHandler(IMessagingContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<ConversationDto>> Handle(GetConversationsRequest request, CancellationToken cancellationToken)
+    {
+        var conversations = await _context.Conversations
+            .Include(c => c.Profiles)
+            .Include(c => c.Messages.OrderByDescending(m => m.CreatedDate).Take(10))
+            .Where(c => c.Profiles.Any(p => p.ProfileId == request.ProfileId))
+            .ToListAsync(cancellationToken);
+
+        return conversations.Select(c => c.ToDto()).ToList();
+    }
+}

--- a/services/messaging/WeddingBidders.Messaging.Api/Features/Messages/MessageDto.cs
+++ b/services/messaging/WeddingBidders.Messaging.Api/Features/Messages/MessageDto.cs
@@ -1,0 +1,50 @@
+using WeddingBidders.Messaging.Core.Model;
+
+namespace WeddingBidders.Messaging.Api.Features.Messages;
+
+public class MessageDto
+{
+    public Guid MessageId { get; set; }
+    public Guid ConversationId { get; set; }
+    public Guid FromProfileId { get; set; }
+    public Guid ToProfileId { get; set; }
+    public string Content { get; set; } = string.Empty;
+    public string? Subject { get; set; }
+    public bool IsRead { get; set; }
+    public DateTime CreatedDate { get; set; }
+}
+
+public class ConversationDto
+{
+    public Guid ConversationId { get; set; }
+    public List<Guid> ProfileIds { get; set; } = new();
+    public List<MessageDto> Messages { get; set; } = new();
+}
+
+public static class MessageExtensions
+{
+    public static MessageDto ToDto(this Message message)
+    {
+        return new MessageDto
+        {
+            MessageId = message.MessageId,
+            ConversationId = message.ConversationId,
+            FromProfileId = message.FromProfileId,
+            ToProfileId = message.ToProfileId,
+            Content = message.Content,
+            Subject = message.Subject,
+            IsRead = message.IsRead,
+            CreatedDate = message.CreatedDate
+        };
+    }
+
+    public static ConversationDto ToDto(this Conversation conversation)
+    {
+        return new ConversationDto
+        {
+            ConversationId = conversation.ConversationId,
+            ProfileIds = conversation.Profiles.Select(p => p.ProfileId).ToList(),
+            Messages = conversation.Messages.Select(m => m.ToDto()).ToList()
+        };
+    }
+}

--- a/services/messaging/WeddingBidders.Messaging.Api/Features/Messages/SendMessage.cs
+++ b/services/messaging/WeddingBidders.Messaging.Api/Features/Messages/SendMessage.cs
@@ -1,0 +1,97 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Messaging.Core;
+using WeddingBidders.Messaging.Core.Model;
+using WeddingBidders.Shared.Core.Events;
+using WeddingBidders.Shared.Messaging;
+
+namespace WeddingBidders.Messaging.Api.Features.Messages;
+
+public class SendMessageRequest : IRequest<MessageDto>
+{
+    public Guid FromProfileId { get; set; }
+    public Guid ToProfileId { get; set; }
+    public string Content { get; set; } = string.Empty;
+    public string? Subject { get; set; }
+}
+
+public class SendMessageRequestValidator : AbstractValidator<SendMessageRequest>
+{
+    public SendMessageRequestValidator()
+    {
+        RuleFor(x => x.FromProfileId).NotEmpty();
+        RuleFor(x => x.ToProfileId).NotEmpty();
+        RuleFor(x => x.Content).NotEmpty();
+    }
+}
+
+public class SendMessageHandler : IRequestHandler<SendMessageRequest, MessageDto>
+{
+    private readonly IMessagingContext _context;
+    private readonly IEventBus _eventBus;
+
+    public SendMessageHandler(IMessagingContext context, IEventBus eventBus)
+    {
+        _context = context;
+        _eventBus = eventBus;
+    }
+
+    public async Task<MessageDto> Handle(SendMessageRequest request, CancellationToken cancellationToken)
+    {
+        // Find or create conversation
+        var conversation = await _context.Conversations
+            .Include(c => c.Profiles)
+            .FirstOrDefaultAsync(c =>
+                c.Profiles.Any(p => p.ProfileId == request.FromProfileId) &&
+                c.Profiles.Any(p => p.ProfileId == request.ToProfileId),
+                cancellationToken);
+
+        if (conversation == null)
+        {
+            conversation = new Conversation
+            {
+                ConversationId = Guid.NewGuid(),
+                CreatedDate = DateTime.UtcNow,
+                Profiles = new List<ConversationProfile>
+                {
+                    new() { ProfileId = request.FromProfileId },
+                    new() { ProfileId = request.ToProfileId }
+                }
+            };
+            _context.Conversations.Add(conversation);
+
+            await _eventBus.PublishAsync(new ConversationCreatedEvent
+            {
+                ConversationId = conversation.ConversationId,
+                ProfileIds = new List<Guid> { request.FromProfileId, request.ToProfileId }
+            }, cancellationToken);
+        }
+
+        var message = new Message
+        {
+            MessageId = Guid.NewGuid(),
+            ConversationId = conversation.ConversationId,
+            FromProfileId = request.FromProfileId,
+            ToProfileId = request.ToProfileId,
+            Content = request.Content,
+            Subject = request.Subject,
+            IsRead = false,
+            CreatedDate = DateTime.UtcNow
+        };
+
+        _context.Messages.Add(message);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await _eventBus.PublishAsync(new MessageSentEvent
+        {
+            MessageId = message.MessageId,
+            ConversationId = conversation.ConversationId,
+            FromProfileId = message.FromProfileId,
+            ToProfileId = message.ToProfileId,
+            Content = message.Content
+        }, cancellationToken);
+
+        return message.ToDto();
+    }
+}

--- a/services/messaging/WeddingBidders.Messaging.Api/Program.cs
+++ b/services/messaging/WeddingBidders.Messaging.Api/Program.cs
@@ -1,0 +1,106 @@
+using System.Text;
+using FluentValidation;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using Serilog;
+using WeddingBidders.Messaging.Core;
+using WeddingBidders.Messaging.Infrastructure;
+using WeddingBidders.Messaging.Infrastructure.Seeding;
+using WeddingBidders.Shared.Messaging;
+
+var builder = WebApplication.CreateBuilder(args);
+
+Log.Logger = new LoggerConfiguration()
+    .ReadFrom.Configuration(builder.Configuration)
+    .Enrich.FromLogContext()
+    .WriteTo.Console()
+    .CreateLogger();
+
+builder.Host.UseSerilog();
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Messaging Service API", Version = "v1" });
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Description = "JWT Authorization header",
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = "Bearer"
+    });
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        { new OpenApiSecurityScheme { Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer" } }, Array.Empty<string>() }
+    });
+});
+
+builder.Services.AddDbContext<MessagingContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("MessagingConnection")));
+builder.Services.AddScoped<IMessagingContext>(sp => sp.GetRequiredService<MessagingContext>());
+builder.Services.AddScoped<MessagingSeedingService>();
+
+builder.Services.AddRedisEventBus(builder.Configuration.GetConnectionString("Redis")!);
+builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Program).Assembly));
+builder.Services.AddValidatorsFromAssembly(typeof(Program).Assembly);
+
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddAuthorization();
+
+var jwtKey = builder.Configuration["Jwt:SecretKey"]!;
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey)),
+            ValidateIssuer = true,
+            ValidIssuer = builder.Configuration["Jwt:Issuer"],
+            ValidateAudience = true,
+            ValidAudience = builder.Configuration["Jwt:Audience"],
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.Zero
+        };
+    });
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("CorsPolicy", policy =>
+    {
+        policy.WithOrigins(builder.Configuration["Cors:Origins"]?.Split(',') ?? Array.Empty<string>())
+            .AllowAnyMethod().AllowAnyHeader().AllowCredentials();
+    });
+});
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider.GetRequiredService<MessagingContext>();
+    if (app.Environment.IsDevelopment())
+    {
+        await context.Database.EnsureCreatedAsync();
+    }
+}
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseCors("CorsPolicy");
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseSerilogRequestLogging();
+app.MapControllers();
+
+app.Run();
+
+public partial class Program { }

--- a/services/messaging/WeddingBidders.Messaging.Api/WeddingBidders.Messaging.Api.csproj
+++ b/services/messaging/WeddingBidders.Messaging.Api/WeddingBidders.Messaging.Api.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="MediatR" Version="12.2.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WeddingBidders.Messaging.Core\WeddingBidders.Messaging.Core.csproj" />
+    <ProjectReference Include="..\WeddingBidders.Messaging.Infrastructure\WeddingBidders.Messaging.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\shared\WeddingBidders.Shared.Messaging\WeddingBidders.Shared.Messaging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/messaging/WeddingBidders.Messaging.Api/appsettings.json
+++ b/services/messaging/WeddingBidders.Messaging.Api/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Serilog": {
+    "MinimumLevel": { "Default": "Information" },
+    "WriteTo": [{ "Name": "Console" }],
+    "Properties": { "Application": "MessagingService" }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "MessagingConnection": "Server=localhost;Database=WeddingBidders_Messaging;Trusted_Connection=True;TrustServerCertificate=True",
+    "Redis": "localhost:6379"
+  },
+  "Jwt": {
+    "SecretKey": "WeddingBiddersSecretKeyForJwtTokenGenerationMustBe32CharsLong!",
+    "Issuer": "localhost",
+    "Audience": "all",
+    "ExpirationMinutes": 10080
+  },
+  "Cors": { "Origins": "http://localhost:4200" }
+}

--- a/services/messaging/WeddingBidders.Messaging.Core/IMessagingContext.cs
+++ b/services/messaging/WeddingBidders.Messaging.Core/IMessagingContext.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Messaging.Core.Model;
+
+namespace WeddingBidders.Messaging.Core;
+
+public interface IMessagingContext
+{
+    DbSet<Message> Messages { get; }
+    DbSet<Conversation> Conversations { get; }
+    DbSet<ConversationProfile> ConversationProfiles { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/services/messaging/WeddingBidders.Messaging.Core/Model/Conversation.cs
+++ b/services/messaging/WeddingBidders.Messaging.Core/Model/Conversation.cs
@@ -1,0 +1,17 @@
+using WeddingBidders.Shared.Core;
+
+namespace WeddingBidders.Messaging.Core.Model;
+
+public class Conversation : BaseEntity
+{
+    public Guid ConversationId { get; set; }
+    public ICollection<ConversationProfile> Profiles { get; set; } = new List<ConversationProfile>();
+    public ICollection<Message> Messages { get; set; } = new List<Message>();
+}
+
+public class ConversationProfile
+{
+    public Guid ConversationId { get; set; }
+    public Conversation? Conversation { get; set; }
+    public Guid ProfileId { get; set; }
+}

--- a/services/messaging/WeddingBidders.Messaging.Core/Model/Message.cs
+++ b/services/messaging/WeddingBidders.Messaging.Core/Model/Message.cs
@@ -1,0 +1,15 @@
+using WeddingBidders.Shared.Core;
+
+namespace WeddingBidders.Messaging.Core.Model;
+
+public class Message : BaseEntity
+{
+    public Guid MessageId { get; set; }
+    public Guid ConversationId { get; set; }
+    public Conversation? Conversation { get; set; }
+    public Guid FromProfileId { get; set; }
+    public Guid ToProfileId { get; set; }
+    public string Content { get; set; } = string.Empty;
+    public string? Subject { get; set; }
+    public bool IsRead { get; set; }
+}

--- a/services/messaging/WeddingBidders.Messaging.Core/WeddingBidders.Messaging.Core.csproj
+++ b/services/messaging/WeddingBidders.Messaging.Core/WeddingBidders.Messaging.Core.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\shared\WeddingBidders.Shared.Core\WeddingBidders.Shared.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/messaging/WeddingBidders.Messaging.Infrastructure/MessagingContext.cs
+++ b/services/messaging/WeddingBidders.Messaging.Infrastructure/MessagingContext.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Messaging.Core;
+using WeddingBidders.Messaging.Core.Model;
+
+namespace WeddingBidders.Messaging.Infrastructure;
+
+public class MessagingContext : DbContext, IMessagingContext
+{
+    public MessagingContext(DbContextOptions<MessagingContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Message> Messages => Set<Message>();
+    public DbSet<Conversation> Conversations => Set<Conversation>();
+    public DbSet<ConversationProfile> ConversationProfiles => Set<ConversationProfile>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Message>(entity =>
+        {
+            entity.HasKey(m => m.MessageId);
+            entity.Property(m => m.Content).IsRequired();
+            entity.HasQueryFilter(m => !m.IsDeleted);
+        });
+
+        modelBuilder.Entity<Conversation>(entity =>
+        {
+            entity.HasKey(c => c.ConversationId);
+            entity.HasQueryFilter(c => !c.IsDeleted);
+            entity.HasMany(c => c.Messages)
+                .WithOne(m => m.Conversation)
+                .HasForeignKey(m => m.ConversationId);
+        });
+
+        modelBuilder.Entity<ConversationProfile>(entity =>
+        {
+            entity.HasKey(cp => new { cp.ConversationId, cp.ProfileId });
+            entity.HasOne(cp => cp.Conversation)
+                .WithMany(c => c.Profiles)
+                .HasForeignKey(cp => cp.ConversationId);
+        });
+
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/services/messaging/WeddingBidders.Messaging.Infrastructure/Seeding/MessagingSeedingService.cs
+++ b/services/messaging/WeddingBidders.Messaging.Infrastructure/Seeding/MessagingSeedingService.cs
@@ -1,0 +1,19 @@
+using WeddingBidders.Messaging.Core;
+
+namespace WeddingBidders.Messaging.Infrastructure.Seeding;
+
+public class MessagingSeedingService
+{
+    private readonly IMessagingContext _context;
+
+    public MessagingSeedingService(IMessagingContext context)
+    {
+        _context = context;
+    }
+
+    public async Task SeedAsync()
+    {
+        // Messages are created through the API, no seeding needed
+        await Task.CompletedTask;
+    }
+}

--- a/services/messaging/WeddingBidders.Messaging.Infrastructure/WeddingBidders.Messaging.Infrastructure.csproj
+++ b/services/messaging/WeddingBidders.Messaging.Infrastructure/WeddingBidders.Messaging.Infrastructure.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WeddingBidders.Messaging.Core\WeddingBidders.Messaging.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/shared/WeddingBidders.Shared.Core/BaseEntity.cs
+++ b/services/shared/WeddingBidders.Shared.Core/BaseEntity.cs
@@ -1,0 +1,8 @@
+namespace WeddingBidders.Shared.Core;
+
+public abstract class BaseEntity
+{
+    public bool IsDeleted { get; set; }
+    public DateTime CreatedDate { get; set; }
+    public DateTime? LastModifiedDate { get; set; }
+}

--- a/services/shared/WeddingBidders.Shared.Core/Events/BiddingEvents.cs
+++ b/services/shared/WeddingBidders.Shared.Core/Events/BiddingEvents.cs
@@ -1,0 +1,54 @@
+using MessagePack;
+
+namespace WeddingBidders.Shared.Core.Events;
+
+[MessagePackObject]
+public class BidderRegisteredEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid BidderId { get; set; }
+
+    [Key(4)]
+    public Guid ProfileId { get; set; }
+
+    [Key(5)]
+    public string Email { get; set; } = string.Empty;
+
+    [Key(6)]
+    public string CompanyName { get; set; } = string.Empty;
+
+    [Key(7)]
+    public string BidderType { get; set; } = string.Empty;
+}
+
+[MessagePackObject]
+public class BidCreatedEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid BidId { get; set; }
+
+    [Key(4)]
+    public Guid WeddingId { get; set; }
+
+    [Key(5)]
+    public Guid BidderId { get; set; }
+
+    [Key(6)]
+    public decimal Price { get; set; }
+
+    [Key(7)]
+    public string Description { get; set; } = string.Empty;
+}
+
+[MessagePackObject]
+public class BidAcceptedEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid BidId { get; set; }
+
+    [Key(4)]
+    public Guid WeddingId { get; set; }
+
+    [Key(5)]
+    public Guid BidderId { get; set; }
+}

--- a/services/shared/WeddingBidders.Shared.Core/Events/IntegrationEvent.cs
+++ b/services/shared/WeddingBidders.Shared.Core/Events/IntegrationEvent.cs
@@ -1,0 +1,16 @@
+using MessagePack;
+
+namespace WeddingBidders.Shared.Core.Events;
+
+[MessagePackObject]
+public abstract class IntegrationEvent
+{
+    [Key(0)]
+    public Guid EventId { get; set; } = Guid.NewGuid();
+
+    [Key(1)]
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+
+    [Key(2)]
+    public string EventType => GetType().Name;
+}

--- a/services/shared/WeddingBidders.Shared.Core/Events/MessagingEvents.cs
+++ b/services/shared/WeddingBidders.Shared.Core/Events/MessagingEvents.cs
@@ -1,0 +1,32 @@
+using MessagePack;
+
+namespace WeddingBidders.Shared.Core.Events;
+
+[MessagePackObject]
+public class MessageSentEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid MessageId { get; set; }
+
+    [Key(4)]
+    public Guid ConversationId { get; set; }
+
+    [Key(5)]
+    public Guid FromProfileId { get; set; }
+
+    [Key(6)]
+    public Guid ToProfileId { get; set; }
+
+    [Key(7)]
+    public string Content { get; set; } = string.Empty;
+}
+
+[MessagePackObject]
+public class ConversationCreatedEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid ConversationId { get; set; }
+
+    [Key(4)]
+    public List<Guid> ProfileIds { get; set; } = new();
+}

--- a/services/shared/WeddingBidders.Shared.Core/Events/SubscriptionEvents.cs
+++ b/services/shared/WeddingBidders.Shared.Core/Events/SubscriptionEvents.cs
@@ -1,0 +1,38 @@
+using MessagePack;
+
+namespace WeddingBidders.Shared.Core.Events;
+
+[MessagePackObject]
+public class SubscriptionCreatedEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid SubscriptionId { get; set; }
+
+    [Key(4)]
+    public Guid AccountId { get; set; }
+
+    [Key(5)]
+    public Guid PlanId { get; set; }
+
+    [Key(6)]
+    public DateTime EffectiveDate { get; set; }
+
+    [Key(7)]
+    public DateTime ExpiryDate { get; set; }
+}
+
+[MessagePackObject]
+public class PaymentProcessedEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid PaymentId { get; set; }
+
+    [Key(4)]
+    public Guid SubscriptionId { get; set; }
+
+    [Key(5)]
+    public decimal Amount { get; set; }
+
+    [Key(6)]
+    public string Status { get; set; } = string.Empty;
+}

--- a/services/shared/WeddingBidders.Shared.Core/Events/SupportEvents.cs
+++ b/services/shared/WeddingBidders.Shared.Core/Events/SupportEvents.cs
@@ -1,0 +1,29 @@
+using MessagePack;
+
+namespace WeddingBidders.Shared.Core.Events;
+
+[MessagePackObject]
+public class IssueCreatedEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid IssueId { get; set; }
+
+    [Key(4)]
+    public Guid ReportedByProfileId { get; set; }
+
+    [Key(5)]
+    public string Subject { get; set; } = string.Empty;
+
+    [Key(6)]
+    public string Content { get; set; } = string.Empty;
+}
+
+[MessagePackObject]
+public class IssueResolvedEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid IssueId { get; set; }
+
+    [Key(4)]
+    public string Resolution { get; set; } = string.Empty;
+}

--- a/services/shared/WeddingBidders.Shared.Core/Events/UserEvents.cs
+++ b/services/shared/WeddingBidders.Shared.Core/Events/UserEvents.cs
@@ -1,0 +1,33 @@
+using MessagePack;
+
+namespace WeddingBidders.Shared.Core.Events;
+
+[MessagePackObject]
+public class UserCreatedEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid UserId { get; set; }
+
+    [Key(4)]
+    public string Username { get; set; } = string.Empty;
+}
+
+[MessagePackObject]
+public class UserDeletedEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid UserId { get; set; }
+}
+
+[MessagePackObject]
+public class ProfileCreatedEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid ProfileId { get; set; }
+
+    [Key(4)]
+    public Guid UserId { get; set; }
+
+    [Key(5)]
+    public string ProfileType { get; set; } = string.Empty;
+}

--- a/services/shared/WeddingBidders.Shared.Core/Events/WeddingEvents.cs
+++ b/services/shared/WeddingBidders.Shared.Core/Events/WeddingEvents.cs
@@ -1,0 +1,64 @@
+using MessagePack;
+
+namespace WeddingBidders.Shared.Core.Events;
+
+[MessagePackObject]
+public class WeddingCreatedEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid WeddingId { get; set; }
+
+    [Key(4)]
+    public Guid CustomerId { get; set; }
+
+    [Key(5)]
+    public string Location { get; set; } = string.Empty;
+
+    [Key(6)]
+    public DateTime WeddingDate { get; set; }
+
+    [Key(7)]
+    public int NumberOfGuests { get; set; }
+}
+
+[MessagePackObject]
+public class WeddingUpdatedEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid WeddingId { get; set; }
+
+    [Key(4)]
+    public string Location { get; set; } = string.Empty;
+
+    [Key(5)]
+    public DateTime WeddingDate { get; set; }
+
+    [Key(6)]
+    public int NumberOfGuests { get; set; }
+}
+
+[MessagePackObject]
+public class WeddingDeletedEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid WeddingId { get; set; }
+}
+
+[MessagePackObject]
+public class CustomerRegisteredEvent : IntegrationEvent
+{
+    [Key(3)]
+    public Guid CustomerId { get; set; }
+
+    [Key(4)]
+    public Guid ProfileId { get; set; }
+
+    [Key(5)]
+    public string Email { get; set; } = string.Empty;
+
+    [Key(6)]
+    public string FirstName { get; set; } = string.Empty;
+
+    [Key(7)]
+    public string LastName { get; set; } = string.Empty;
+}

--- a/services/shared/WeddingBidders.Shared.Core/WeddingBidders.Shared.Core.csproj
+++ b/services/shared/WeddingBidders.Shared.Core/WeddingBidders.Shared.Core.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MessagePack" Version="2.5.140" />
+  </ItemGroup>
+
+</Project>

--- a/services/shared/WeddingBidders.Shared.Messaging/EventBusBackgroundService.cs
+++ b/services/shared/WeddingBidders.Shared.Messaging/EventBusBackgroundService.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using WeddingBidders.Shared.Core.Events;
+
+namespace WeddingBidders.Shared.Messaging;
+
+public class EventBusBackgroundService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<EventBusBackgroundService> _logger;
+    private readonly List<EventSubscription> _subscriptions;
+
+    public EventBusBackgroundService(
+        IServiceProvider serviceProvider,
+        ILogger<EventBusBackgroundService> logger,
+        IEnumerable<EventSubscription> subscriptions)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+        _subscriptions = subscriptions.ToList();
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Event Bus Background Service is starting");
+
+        using var scope = _serviceProvider.CreateScope();
+        var eventBus = scope.ServiceProvider.GetRequiredService<IEventBus>();
+
+        foreach (var subscription in _subscriptions)
+        {
+            await subscription.Subscribe(eventBus, scope.ServiceProvider, stoppingToken);
+            _logger.LogInformation("Subscribed to event type {EventType}", subscription.EventType.Name);
+        }
+
+        await Task.Delay(Timeout.Infinite, stoppingToken);
+    }
+}
+
+public class EventSubscription
+{
+    public Type EventType { get; }
+    public Type HandlerType { get; }
+
+    public EventSubscription(Type eventType, Type handlerType)
+    {
+        EventType = eventType;
+        HandlerType = handlerType;
+    }
+
+    public async Task Subscribe(IEventBus eventBus, IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        var subscribeMethod = typeof(IEventBus)
+            .GetMethod(nameof(IEventBus.SubscribeAsync))!
+            .MakeGenericMethod(EventType);
+
+        var handlerInstance = serviceProvider.GetRequiredService(HandlerType);
+        var handleMethod = HandlerType.GetMethod("HandleAsync")!;
+
+        var handler = Delegate.CreateDelegate(
+            typeof(Func<,>).MakeGenericType(EventType, typeof(Task)),
+            handlerInstance,
+            handleMethod);
+
+        await (Task)subscribeMethod.Invoke(eventBus, new object[] { handler, cancellationToken })!;
+    }
+}

--- a/services/shared/WeddingBidders.Shared.Messaging/IEventBus.cs
+++ b/services/shared/WeddingBidders.Shared.Messaging/IEventBus.cs
@@ -1,0 +1,9 @@
+using WeddingBidders.Shared.Core.Events;
+
+namespace WeddingBidders.Shared.Messaging;
+
+public interface IEventBus
+{
+    Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default) where T : IntegrationEvent;
+    Task SubscribeAsync<T>(Func<T, Task> handler, CancellationToken cancellationToken = default) where T : IntegrationEvent;
+}

--- a/services/shared/WeddingBidders.Shared.Messaging/IEventHandler.cs
+++ b/services/shared/WeddingBidders.Shared.Messaging/IEventHandler.cs
@@ -1,0 +1,8 @@
+using WeddingBidders.Shared.Core.Events;
+
+namespace WeddingBidders.Shared.Messaging;
+
+public interface IEventHandler<in TEvent> where TEvent : IntegrationEvent
+{
+    Task HandleAsync(TEvent @event, CancellationToken cancellationToken = default);
+}

--- a/services/shared/WeddingBidders.Shared.Messaging/MessagePackSerializer.cs
+++ b/services/shared/WeddingBidders.Shared.Messaging/MessagePackSerializer.cs
@@ -1,0 +1,30 @@
+using MessagePack;
+using MessagePack.Resolvers;
+using WeddingBidders.Shared.Core.Events;
+
+namespace WeddingBidders.Shared.Messaging;
+
+public static class EventSerializer
+{
+    private static readonly MessagePackSerializerOptions Options = MessagePackSerializerOptions.Standard
+        .WithResolver(CompositeResolver.Create(
+            StandardResolver.Instance,
+            ContractlessStandardResolver.Instance
+        ))
+        .WithCompression(MessagePackCompression.Lz4BlockArray);
+
+    public static byte[] Serialize<T>(T @event) where T : IntegrationEvent
+    {
+        return MessagePackSerializer.Serialize(@event, Options);
+    }
+
+    public static T Deserialize<T>(byte[] data) where T : IntegrationEvent
+    {
+        return MessagePackSerializer.Deserialize<T>(data, Options);
+    }
+
+    public static object Deserialize(byte[] data, Type type)
+    {
+        return MessagePackSerializer.Deserialize(type, data, Options);
+    }
+}

--- a/services/shared/WeddingBidders.Shared.Messaging/RedisEventBus.cs
+++ b/services/shared/WeddingBidders.Shared.Messaging/RedisEventBus.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+using WeddingBidders.Shared.Core.Events;
+
+namespace WeddingBidders.Shared.Messaging;
+
+public class RedisEventBus : IEventBus, IDisposable
+{
+    private readonly IConnectionMultiplexer _redis;
+    private readonly ISubscriber _subscriber;
+    private readonly ILogger<RedisEventBus> _logger;
+    private readonly Dictionary<Type, List<Delegate>> _handlers = new();
+    private readonly SemaphoreSlim _lock = new(1, 1);
+
+    public RedisEventBus(IConnectionMultiplexer redis, ILogger<RedisEventBus> logger)
+    {
+        _redis = redis;
+        _subscriber = redis.GetSubscriber();
+        _logger = logger;
+    }
+
+    public async Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default) where T : IntegrationEvent
+    {
+        var channel = GetChannelName<T>();
+        var data = EventSerializer.Serialize(@event);
+
+        _logger.LogInformation(
+            "Publishing event {EventType} with ID {EventId} to channel {Channel}",
+            @event.EventType,
+            @event.EventId,
+            channel);
+
+        await _subscriber.PublishAsync(RedisChannel.Literal(channel), data);
+    }
+
+    public async Task SubscribeAsync<T>(Func<T, Task> handler, CancellationToken cancellationToken = default) where T : IntegrationEvent
+    {
+        var channel = GetChannelName<T>();
+        var eventType = typeof(T);
+
+        await _lock.WaitAsync(cancellationToken);
+        try
+        {
+            if (!_handlers.ContainsKey(eventType))
+            {
+                _handlers[eventType] = new List<Delegate>();
+
+                await _subscriber.SubscribeAsync(RedisChannel.Literal(channel), async (ch, message) =>
+                {
+                    try
+                    {
+                        if (message.HasValue)
+                        {
+                            var @event = EventSerializer.Deserialize<T>((byte[])message!);
+
+                            _logger.LogInformation(
+                                "Received event {EventType} with ID {EventId} from channel {Channel}",
+                                @event.EventType,
+                                @event.EventId,
+                                channel);
+
+                            if (_handlers.TryGetValue(eventType, out var handlers))
+                            {
+                                foreach (var h in handlers.Cast<Func<T, Task>>())
+                                {
+                                    await h(@event);
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Error processing event from channel {Channel}", channel);
+                    }
+                });
+            }
+
+            _handlers[eventType].Add(handler);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+
+        _logger.LogInformation("Subscribed to channel {Channel} for event type {EventType}", channel, eventType.Name);
+    }
+
+    private static string GetChannelName<T>() where T : IntegrationEvent
+    {
+        return $"wedding-bidders:{typeof(T).Name}";
+    }
+
+    public void Dispose()
+    {
+        _lock.Dispose();
+    }
+}

--- a/services/shared/WeddingBidders.Shared.Messaging/ServiceCollectionExtensions.cs
+++ b/services/shared/WeddingBidders.Shared.Messaging/ServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
+using WeddingBidders.Shared.Core.Events;
+
+namespace WeddingBidders.Shared.Messaging;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddRedisEventBus(this IServiceCollection services, string connectionString)
+    {
+        services.AddSingleton<IConnectionMultiplexer>(sp =>
+            ConnectionMultiplexer.Connect(connectionString));
+
+        services.AddSingleton<IEventBus, RedisEventBus>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddEventHandler<TEvent, THandler>(this IServiceCollection services)
+        where TEvent : IntegrationEvent
+        where THandler : class, IEventHandler<TEvent>
+    {
+        services.AddScoped<THandler>();
+        services.AddSingleton(new EventSubscription(typeof(TEvent), typeof(THandler)));
+
+        return services;
+    }
+
+    public static IServiceCollection AddEventBusBackgroundService(this IServiceCollection services)
+    {
+        services.AddHostedService<EventBusBackgroundService>();
+        return services;
+    }
+}

--- a/services/shared/WeddingBidders.Shared.Messaging/WeddingBidders.Shared.Messaging.csproj
+++ b/services/shared/WeddingBidders.Shared.Messaging/WeddingBidders.Shared.Messaging.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StackExchange.Redis" Version="2.7.10" />
+    <PackageReference Include="MessagePack" Version="2.5.140" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WeddingBidders.Shared.Core\WeddingBidders.Shared.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/subscription/WeddingBidders.Subscription.Api/Controllers/SubscriptionsController.cs
+++ b/services/subscription/WeddingBidders.Subscription.Api/Controllers/SubscriptionsController.cs
@@ -1,0 +1,41 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using WeddingBidders.Subscription.Api.Features.Subscriptions;
+
+namespace WeddingBidders.Subscription.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class SubscriptionsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public SubscriptionsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<SubscriptionDto>> CreateSubscription([FromBody] CreateSubscriptionRequest request)
+    {
+        try
+        {
+            var subscription = await _mediator.Send(request);
+            return CreatedAtAction(nameof(GetPlans), subscription);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpGet("plans")]
+    [AllowAnonymous]
+    public async Task<ActionResult<List<PlanDto>>> GetPlans()
+    {
+        var plans = await _mediator.Send(new GetPlansRequest());
+        return Ok(plans);
+    }
+}

--- a/services/subscription/WeddingBidders.Subscription.Api/Dockerfile
+++ b/services/subscription/WeddingBidders.Subscription.Api/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["shared/WeddingBidders.Shared.Core/WeddingBidders.Shared.Core.csproj", "shared/WeddingBidders.Shared.Core/"]
+COPY ["shared/WeddingBidders.Shared.Messaging/WeddingBidders.Shared.Messaging.csproj", "shared/WeddingBidders.Shared.Messaging/"]
+COPY ["subscription/WeddingBidders.Subscription.Core/WeddingBidders.Subscription.Core.csproj", "subscription/WeddingBidders.Subscription.Core/"]
+COPY ["subscription/WeddingBidders.Subscription.Infrastructure/WeddingBidders.Subscription.Infrastructure.csproj", "subscription/WeddingBidders.Subscription.Infrastructure/"]
+COPY ["subscription/WeddingBidders.Subscription.Api/WeddingBidders.Subscription.Api.csproj", "subscription/WeddingBidders.Subscription.Api/"]
+RUN dotnet restore "subscription/WeddingBidders.Subscription.Api/WeddingBidders.Subscription.Api.csproj"
+COPY . .
+WORKDIR "/src/subscription/WeddingBidders.Subscription.Api"
+RUN dotnet build "WeddingBidders.Subscription.Api.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "WeddingBidders.Subscription.Api.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "WeddingBidders.Subscription.Api.dll"]

--- a/services/subscription/WeddingBidders.Subscription.Api/Features/Subscriptions/CreateSubscription.cs
+++ b/services/subscription/WeddingBidders.Subscription.Api/Features/Subscriptions/CreateSubscription.cs
@@ -1,0 +1,73 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Shared.Core.Events;
+using WeddingBidders.Shared.Messaging;
+using WeddingBidders.Subscription.Core;
+using WeddingBidders.Subscription.Core.Model;
+
+namespace WeddingBidders.Subscription.Api.Features.Subscriptions;
+
+public class CreateSubscriptionRequest : IRequest<SubscriptionDto>
+{
+    public Guid AccountId { get; set; }
+    public Guid PlanId { get; set; }
+}
+
+public class CreateSubscriptionRequestValidator : AbstractValidator<CreateSubscriptionRequest>
+{
+    public CreateSubscriptionRequestValidator()
+    {
+        RuleFor(x => x.AccountId).NotEmpty();
+        RuleFor(x => x.PlanId).NotEmpty();
+    }
+}
+
+public class CreateSubscriptionHandler : IRequestHandler<CreateSubscriptionRequest, SubscriptionDto>
+{
+    private readonly ISubscriptionContext _context;
+    private readonly IEventBus _eventBus;
+
+    public CreateSubscriptionHandler(ISubscriptionContext context, IEventBus eventBus)
+    {
+        _context = context;
+        _eventBus = eventBus;
+    }
+
+    public async Task<SubscriptionDto> Handle(CreateSubscriptionRequest request, CancellationToken cancellationToken)
+    {
+        var plan = await _context.Plans
+            .FirstOrDefaultAsync(p => p.PlanId == request.PlanId, cancellationToken);
+
+        if (plan == null)
+        {
+            throw new InvalidOperationException("Plan not found");
+        }
+
+        var subscription = new Core.Model.Subscription
+        {
+            SubscriptionId = Guid.NewGuid(),
+            AccountId = request.AccountId,
+            PlanId = request.PlanId,
+            Plan = plan,
+            EffectiveDate = DateTime.UtcNow,
+            ExpiryDate = DateTime.UtcNow.AddDays(plan.DurationDays),
+            Status = SubscriptionStatus.Active,
+            CreatedDate = DateTime.UtcNow
+        };
+
+        _context.Subscriptions.Add(subscription);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await _eventBus.PublishAsync(new SubscriptionCreatedEvent
+        {
+            SubscriptionId = subscription.SubscriptionId,
+            AccountId = subscription.AccountId,
+            PlanId = subscription.PlanId,
+            EffectiveDate = subscription.EffectiveDate,
+            ExpiryDate = subscription.ExpiryDate
+        }, cancellationToken);
+
+        return subscription.ToDto();
+    }
+}

--- a/services/subscription/WeddingBidders.Subscription.Api/Features/Subscriptions/GetPlans.cs
+++ b/services/subscription/WeddingBidders.Subscription.Api/Features/Subscriptions/GetPlans.cs
@@ -1,0 +1,25 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Subscription.Core;
+
+namespace WeddingBidders.Subscription.Api.Features.Subscriptions;
+
+public class GetPlansRequest : IRequest<List<PlanDto>>
+{
+}
+
+public class GetPlansHandler : IRequestHandler<GetPlansRequest, List<PlanDto>>
+{
+    private readonly ISubscriptionContext _context;
+
+    public GetPlansHandler(ISubscriptionContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<PlanDto>> Handle(GetPlansRequest request, CancellationToken cancellationToken)
+    {
+        var plans = await _context.Plans.ToListAsync(cancellationToken);
+        return plans.Select(p => p.ToDto()).ToList();
+    }
+}

--- a/services/subscription/WeddingBidders.Subscription.Api/Features/Subscriptions/SubscriptionDto.cs
+++ b/services/subscription/WeddingBidders.Subscription.Api/Features/Subscriptions/SubscriptionDto.cs
@@ -1,0 +1,50 @@
+namespace WeddingBidders.Subscription.Api.Features.Subscriptions;
+
+public class SubscriptionDto
+{
+    public Guid SubscriptionId { get; set; }
+    public Guid AccountId { get; set; }
+    public Guid PlanId { get; set; }
+    public string PlanName { get; set; } = string.Empty;
+    public DateTime EffectiveDate { get; set; }
+    public DateTime ExpiryDate { get; set; }
+    public string Status { get; set; } = string.Empty;
+}
+
+public class PlanDto
+{
+    public Guid PlanId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public int DurationDays { get; set; }
+}
+
+public static class SubscriptionExtensions
+{
+    public static SubscriptionDto ToDto(this Core.Model.Subscription subscription)
+    {
+        return new SubscriptionDto
+        {
+            SubscriptionId = subscription.SubscriptionId,
+            AccountId = subscription.AccountId,
+            PlanId = subscription.PlanId,
+            PlanName = subscription.Plan?.Name ?? string.Empty,
+            EffectiveDate = subscription.EffectiveDate,
+            ExpiryDate = subscription.ExpiryDate,
+            Status = subscription.Status.ToString()
+        };
+    }
+
+    public static PlanDto ToDto(this Core.Model.Plan plan)
+    {
+        return new PlanDto
+        {
+            PlanId = plan.PlanId,
+            Name = plan.Name,
+            Description = plan.Description,
+            Price = plan.Price,
+            DurationDays = plan.DurationDays
+        };
+    }
+}

--- a/services/subscription/WeddingBidders.Subscription.Api/Program.cs
+++ b/services/subscription/WeddingBidders.Subscription.Api/Program.cs
@@ -1,0 +1,108 @@
+using System.Text;
+using FluentValidation;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using Serilog;
+using WeddingBidders.Shared.Messaging;
+using WeddingBidders.Subscription.Core;
+using WeddingBidders.Subscription.Infrastructure;
+using WeddingBidders.Subscription.Infrastructure.Seeding;
+
+var builder = WebApplication.CreateBuilder(args);
+
+Log.Logger = new LoggerConfiguration()
+    .ReadFrom.Configuration(builder.Configuration)
+    .Enrich.FromLogContext()
+    .WriteTo.Console()
+    .CreateLogger();
+
+builder.Host.UseSerilog();
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Subscription Service API", Version = "v1" });
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Description = "JWT Authorization header",
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = "Bearer"
+    });
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        { new OpenApiSecurityScheme { Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer" } }, Array.Empty<string>() }
+    });
+});
+
+builder.Services.AddDbContext<SubscriptionContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("SubscriptionConnection")));
+builder.Services.AddScoped<ISubscriptionContext>(sp => sp.GetRequiredService<SubscriptionContext>());
+builder.Services.AddScoped<SubscriptionSeedingService>();
+
+builder.Services.AddRedisEventBus(builder.Configuration.GetConnectionString("Redis")!);
+builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Program).Assembly));
+builder.Services.AddValidatorsFromAssembly(typeof(Program).Assembly);
+
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddAuthorization();
+
+var jwtKey = builder.Configuration["Jwt:SecretKey"]!;
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey)),
+            ValidateIssuer = true,
+            ValidIssuer = builder.Configuration["Jwt:Issuer"],
+            ValidateAudience = true,
+            ValidAudience = builder.Configuration["Jwt:Audience"],
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.Zero
+        };
+    });
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("CorsPolicy", policy =>
+    {
+        policy.WithOrigins(builder.Configuration["Cors:Origins"]?.Split(',') ?? Array.Empty<string>())
+            .AllowAnyMethod().AllowAnyHeader().AllowCredentials();
+    });
+});
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider.GetRequiredService<SubscriptionContext>();
+    if (app.Environment.IsDevelopment())
+    {
+        await context.Database.EnsureCreatedAsync();
+        var seeder = scope.ServiceProvider.GetRequiredService<SubscriptionSeedingService>();
+        await seeder.SeedAsync();
+    }
+}
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseCors("CorsPolicy");
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseSerilogRequestLogging();
+app.MapControllers();
+
+app.Run();
+
+public partial class Program { }

--- a/services/subscription/WeddingBidders.Subscription.Api/WeddingBidders.Subscription.Api.csproj
+++ b/services/subscription/WeddingBidders.Subscription.Api/WeddingBidders.Subscription.Api.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="MediatR" Version="12.2.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WeddingBidders.Subscription.Core\WeddingBidders.Subscription.Core.csproj" />
+    <ProjectReference Include="..\WeddingBidders.Subscription.Infrastructure\WeddingBidders.Subscription.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\shared\WeddingBidders.Shared.Messaging\WeddingBidders.Shared.Messaging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/subscription/WeddingBidders.Subscription.Api/appsettings.json
+++ b/services/subscription/WeddingBidders.Subscription.Api/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Serilog": {
+    "MinimumLevel": { "Default": "Information" },
+    "WriteTo": [{ "Name": "Console" }],
+    "Properties": { "Application": "SubscriptionService" }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "SubscriptionConnection": "Server=localhost;Database=WeddingBidders_Subscription;Trusted_Connection=True;TrustServerCertificate=True",
+    "Redis": "localhost:6379"
+  },
+  "Jwt": {
+    "SecretKey": "WeddingBiddersSecretKeyForJwtTokenGenerationMustBe32CharsLong!",
+    "Issuer": "localhost",
+    "Audience": "all",
+    "ExpirationMinutes": 10080
+  },
+  "Cors": { "Origins": "http://localhost:4200" }
+}

--- a/services/subscription/WeddingBidders.Subscription.Core/ISubscriptionContext.cs
+++ b/services/subscription/WeddingBidders.Subscription.Core/ISubscriptionContext.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Subscription.Core.Model;
+
+namespace WeddingBidders.Subscription.Core;
+
+public interface ISubscriptionContext
+{
+    DbSet<Model.Subscription> Subscriptions { get; }
+    DbSet<Plan> Plans { get; }
+    DbSet<Payment> Payments { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/services/subscription/WeddingBidders.Subscription.Core/Model/Payment.cs
+++ b/services/subscription/WeddingBidders.Subscription.Core/Model/Payment.cs
@@ -1,0 +1,21 @@
+using WeddingBidders.Shared.Core;
+
+namespace WeddingBidders.Subscription.Core.Model;
+
+public class Payment : BaseEntity
+{
+    public Guid PaymentId { get; set; }
+    public Guid SubscriptionId { get; set; }
+    public Subscription? Subscription { get; set; }
+    public decimal Amount { get; set; }
+    public PaymentStatus Status { get; set; }
+    public string? TransactionId { get; set; }
+}
+
+public enum PaymentStatus
+{
+    Pending = 0,
+    Completed = 1,
+    Failed = 2,
+    Refunded = 3
+}

--- a/services/subscription/WeddingBidders.Subscription.Core/Model/Plan.cs
+++ b/services/subscription/WeddingBidders.Subscription.Core/Model/Plan.cs
@@ -1,0 +1,11 @@
+namespace WeddingBidders.Subscription.Core.Model;
+
+public class Plan
+{
+    public Guid PlanId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public int DurationDays { get; set; }
+    public ICollection<Subscription> Subscriptions { get; set; } = new List<Subscription>();
+}

--- a/services/subscription/WeddingBidders.Subscription.Core/Model/Subscription.cs
+++ b/services/subscription/WeddingBidders.Subscription.Core/Model/Subscription.cs
@@ -1,0 +1,22 @@
+using WeddingBidders.Shared.Core;
+
+namespace WeddingBidders.Subscription.Core.Model;
+
+public class Subscription : BaseEntity
+{
+    public Guid SubscriptionId { get; set; }
+    public Guid AccountId { get; set; }
+    public Guid PlanId { get; set; }
+    public Plan? Plan { get; set; }
+    public DateTime EffectiveDate { get; set; }
+    public DateTime ExpiryDate { get; set; }
+    public SubscriptionStatus Status { get; set; }
+    public ICollection<Payment> Payments { get; set; } = new List<Payment>();
+}
+
+public enum SubscriptionStatus
+{
+    Active = 0,
+    Expired = 1,
+    Cancelled = 2
+}

--- a/services/subscription/WeddingBidders.Subscription.Core/WeddingBidders.Subscription.Core.csproj
+++ b/services/subscription/WeddingBidders.Subscription.Core/WeddingBidders.Subscription.Core.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\shared\WeddingBidders.Shared.Core\WeddingBidders.Shared.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/subscription/WeddingBidders.Subscription.Infrastructure/Seeding/SubscriptionSeedingService.cs
+++ b/services/subscription/WeddingBidders.Subscription.Infrastructure/Seeding/SubscriptionSeedingService.cs
@@ -1,0 +1,57 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Subscription.Core;
+using WeddingBidders.Subscription.Core.Model;
+
+namespace WeddingBidders.Subscription.Infrastructure.Seeding;
+
+public class SubscriptionSeedingService
+{
+    private readonly ISubscriptionContext _context;
+
+    public SubscriptionSeedingService(ISubscriptionContext context)
+    {
+        _context = context;
+    }
+
+    public async Task SeedAsync()
+    {
+        await SeedPlansAsync();
+        await _context.SaveChangesAsync();
+    }
+
+    private async Task SeedPlansAsync()
+    {
+        if (await _context.Plans.AnyAsync())
+            return;
+
+        var plans = new List<Plan>
+        {
+            new()
+            {
+                PlanId = Guid.Parse("00000000-0000-0000-0000-000000000001"),
+                Name = "Basic",
+                Description = "Basic plan for new bidders",
+                Price = 9.99m,
+                DurationDays = 30
+            },
+            new()
+            {
+                PlanId = Guid.Parse("00000000-0000-0000-0000-000000000002"),
+                Name = "Professional",
+                Description = "Professional plan with more features",
+                Price = 29.99m,
+                DurationDays = 30
+            },
+            new()
+            {
+                PlanId = Guid.Parse("00000000-0000-0000-0000-000000000003"),
+                Name = "Premium",
+                Description = "Premium plan with all features",
+                Price = 49.99m,
+                DurationDays = 30
+            }
+        };
+
+        _context.Plans.AddRange(plans);
+    }
+}

--- a/services/subscription/WeddingBidders.Subscription.Infrastructure/SubscriptionContext.cs
+++ b/services/subscription/WeddingBidders.Subscription.Infrastructure/SubscriptionContext.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Subscription.Core;
+using WeddingBidders.Subscription.Core.Model;
+
+namespace WeddingBidders.Subscription.Infrastructure;
+
+public class SubscriptionContext : DbContext, ISubscriptionContext
+{
+    public SubscriptionContext(DbContextOptions<SubscriptionContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Core.Model.Subscription> Subscriptions => Set<Core.Model.Subscription>();
+    public DbSet<Plan> Plans => Set<Plan>();
+    public DbSet<Payment> Payments => Set<Payment>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Core.Model.Subscription>(entity =>
+        {
+            entity.HasKey(s => s.SubscriptionId);
+            entity.HasQueryFilter(s => !s.IsDeleted);
+            entity.HasOne(s => s.Plan).WithMany(p => p.Subscriptions).HasForeignKey(s => s.PlanId);
+            entity.HasMany(s => s.Payments).WithOne(p => p.Subscription).HasForeignKey(p => p.SubscriptionId);
+        });
+
+        modelBuilder.Entity<Plan>(entity =>
+        {
+            entity.HasKey(p => p.PlanId);
+            entity.Property(p => p.Name).IsRequired().HasMaxLength(100);
+            entity.Property(p => p.Price).HasPrecision(18, 2);
+        });
+
+        modelBuilder.Entity<Payment>(entity =>
+        {
+            entity.HasKey(p => p.PaymentId);
+            entity.Property(p => p.Amount).HasPrecision(18, 2);
+            entity.HasQueryFilter(p => !p.IsDeleted);
+        });
+
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/services/subscription/WeddingBidders.Subscription.Infrastructure/WeddingBidders.Subscription.Infrastructure.csproj
+++ b/services/subscription/WeddingBidders.Subscription.Infrastructure/WeddingBidders.Subscription.Infrastructure.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WeddingBidders.Subscription.Core\WeddingBidders.Subscription.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/support/WeddingBidders.Support.Api/Controllers/IssuesController.cs
+++ b/services/support/WeddingBidders.Support.Api/Controllers/IssuesController.cs
@@ -1,0 +1,33 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using WeddingBidders.Support.Api.Features.Issues;
+
+namespace WeddingBidders.Support.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class IssuesController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public IssuesController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<IssueDto>> CreateIssue([FromBody] CreateIssueRequest request)
+    {
+        var issue = await _mediator.Send(request);
+        return CreatedAtAction(nameof(GetAllIssues), issue);
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<IssueDto>>> GetAllIssues()
+    {
+        var issues = await _mediator.Send(new GetAllIssuesRequest());
+        return Ok(issues);
+    }
+}

--- a/services/support/WeddingBidders.Support.Api/Dockerfile
+++ b/services/support/WeddingBidders.Support.Api/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["shared/WeddingBidders.Shared.Core/WeddingBidders.Shared.Core.csproj", "shared/WeddingBidders.Shared.Core/"]
+COPY ["shared/WeddingBidders.Shared.Messaging/WeddingBidders.Shared.Messaging.csproj", "shared/WeddingBidders.Shared.Messaging/"]
+COPY ["support/WeddingBidders.Support.Core/WeddingBidders.Support.Core.csproj", "support/WeddingBidders.Support.Core/"]
+COPY ["support/WeddingBidders.Support.Infrastructure/WeddingBidders.Support.Infrastructure.csproj", "support/WeddingBidders.Support.Infrastructure/"]
+COPY ["support/WeddingBidders.Support.Api/WeddingBidders.Support.Api.csproj", "support/WeddingBidders.Support.Api/"]
+RUN dotnet restore "support/WeddingBidders.Support.Api/WeddingBidders.Support.Api.csproj"
+COPY . .
+WORKDIR "/src/support/WeddingBidders.Support.Api"
+RUN dotnet build "WeddingBidders.Support.Api.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "WeddingBidders.Support.Api.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "WeddingBidders.Support.Api.dll"]

--- a/services/support/WeddingBidders.Support.Api/Features/Issues/CreateIssue.cs
+++ b/services/support/WeddingBidders.Support.Api/Features/Issues/CreateIssue.cs
@@ -1,0 +1,63 @@
+using FluentValidation;
+using MediatR;
+using WeddingBidders.Shared.Core.Events;
+using WeddingBidders.Shared.Messaging;
+using WeddingBidders.Support.Core;
+using WeddingBidders.Support.Core.Model;
+
+namespace WeddingBidders.Support.Api.Features.Issues;
+
+public class CreateIssueRequest : IRequest<IssueDto>
+{
+    public Guid ReportedByProfileId { get; set; }
+    public string Subject { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+}
+
+public class CreateIssueRequestValidator : AbstractValidator<CreateIssueRequest>
+{
+    public CreateIssueRequestValidator()
+    {
+        RuleFor(x => x.ReportedByProfileId).NotEmpty();
+        RuleFor(x => x.Subject).NotEmpty().MaximumLength(200);
+        RuleFor(x => x.Content).NotEmpty();
+    }
+}
+
+public class CreateIssueHandler : IRequestHandler<CreateIssueRequest, IssueDto>
+{
+    private readonly ISupportContext _context;
+    private readonly IEventBus _eventBus;
+
+    public CreateIssueHandler(ISupportContext context, IEventBus eventBus)
+    {
+        _context = context;
+        _eventBus = eventBus;
+    }
+
+    public async Task<IssueDto> Handle(CreateIssueRequest request, CancellationToken cancellationToken)
+    {
+        var issue = new Issue
+        {
+            IssueId = Guid.NewGuid(),
+            ReportedByProfileId = request.ReportedByProfileId,
+            Subject = request.Subject,
+            Content = request.Content,
+            Status = IssueStatus.Open,
+            CreatedDate = DateTime.UtcNow
+        };
+
+        _context.Issues.Add(issue);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await _eventBus.PublishAsync(new IssueCreatedEvent
+        {
+            IssueId = issue.IssueId,
+            ReportedByProfileId = issue.ReportedByProfileId,
+            Subject = issue.Subject,
+            Content = issue.Content
+        }, cancellationToken);
+
+        return issue.ToDto();
+    }
+}

--- a/services/support/WeddingBidders.Support.Api/Features/Issues/GetAllIssues.cs
+++ b/services/support/WeddingBidders.Support.Api/Features/Issues/GetAllIssues.cs
@@ -1,0 +1,28 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Support.Core;
+
+namespace WeddingBidders.Support.Api.Features.Issues;
+
+public class GetAllIssuesRequest : IRequest<List<IssueDto>>
+{
+}
+
+public class GetAllIssuesHandler : IRequestHandler<GetAllIssuesRequest, List<IssueDto>>
+{
+    private readonly ISupportContext _context;
+
+    public GetAllIssuesHandler(ISupportContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<IssueDto>> Handle(GetAllIssuesRequest request, CancellationToken cancellationToken)
+    {
+        var issues = await _context.Issues
+            .OrderByDescending(i => i.CreatedDate)
+            .ToListAsync(cancellationToken);
+
+        return issues.Select(i => i.ToDto()).ToList();
+    }
+}

--- a/services/support/WeddingBidders.Support.Api/Features/Issues/IssueDto.cs
+++ b/services/support/WeddingBidders.Support.Api/Features/Issues/IssueDto.cs
@@ -1,0 +1,33 @@
+using WeddingBidders.Support.Core.Model;
+
+namespace WeddingBidders.Support.Api.Features.Issues;
+
+public class IssueDto
+{
+    public Guid IssueId { get; set; }
+    public Guid ReportedByProfileId { get; set; }
+    public string Subject { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public string? Resolution { get; set; }
+    public DateTime CreatedDate { get; set; }
+    public DateTime? ResolvedDate { get; set; }
+}
+
+public static class IssueExtensions
+{
+    public static IssueDto ToDto(this Issue issue)
+    {
+        return new IssueDto
+        {
+            IssueId = issue.IssueId,
+            ReportedByProfileId = issue.ReportedByProfileId,
+            Subject = issue.Subject,
+            Content = issue.Content,
+            Status = issue.Status.ToString(),
+            Resolution = issue.Resolution,
+            CreatedDate = issue.CreatedDate,
+            ResolvedDate = issue.ResolvedDate
+        };
+    }
+}

--- a/services/support/WeddingBidders.Support.Api/Program.cs
+++ b/services/support/WeddingBidders.Support.Api/Program.cs
@@ -1,0 +1,106 @@
+using System.Text;
+using FluentValidation;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using Serilog;
+using WeddingBidders.Shared.Messaging;
+using WeddingBidders.Support.Core;
+using WeddingBidders.Support.Infrastructure;
+using WeddingBidders.Support.Infrastructure.Seeding;
+
+var builder = WebApplication.CreateBuilder(args);
+
+Log.Logger = new LoggerConfiguration()
+    .ReadFrom.Configuration(builder.Configuration)
+    .Enrich.FromLogContext()
+    .WriteTo.Console()
+    .CreateLogger();
+
+builder.Host.UseSerilog();
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Support Service API", Version = "v1" });
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Description = "JWT Authorization header",
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = "Bearer"
+    });
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        { new OpenApiSecurityScheme { Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer" } }, Array.Empty<string>() }
+    });
+});
+
+builder.Services.AddDbContext<SupportContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("SupportConnection")));
+builder.Services.AddScoped<ISupportContext>(sp => sp.GetRequiredService<SupportContext>());
+builder.Services.AddScoped<SupportSeedingService>();
+
+builder.Services.AddRedisEventBus(builder.Configuration.GetConnectionString("Redis")!);
+builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Program).Assembly));
+builder.Services.AddValidatorsFromAssembly(typeof(Program).Assembly);
+
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddAuthorization();
+
+var jwtKey = builder.Configuration["Jwt:SecretKey"]!;
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey)),
+            ValidateIssuer = true,
+            ValidIssuer = builder.Configuration["Jwt:Issuer"],
+            ValidateAudience = true,
+            ValidAudience = builder.Configuration["Jwt:Audience"],
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.Zero
+        };
+    });
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("CorsPolicy", policy =>
+    {
+        policy.WithOrigins(builder.Configuration["Cors:Origins"]?.Split(',') ?? Array.Empty<string>())
+            .AllowAnyMethod().AllowAnyHeader().AllowCredentials();
+    });
+});
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider.GetRequiredService<SupportContext>();
+    if (app.Environment.IsDevelopment())
+    {
+        await context.Database.EnsureCreatedAsync();
+    }
+}
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseCors("CorsPolicy");
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseSerilogRequestLogging();
+app.MapControllers();
+
+app.Run();
+
+public partial class Program { }

--- a/services/support/WeddingBidders.Support.Api/WeddingBidders.Support.Api.csproj
+++ b/services/support/WeddingBidders.Support.Api/WeddingBidders.Support.Api.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="MediatR" Version="12.2.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WeddingBidders.Support.Core\WeddingBidders.Support.Core.csproj" />
+    <ProjectReference Include="..\WeddingBidders.Support.Infrastructure\WeddingBidders.Support.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\shared\WeddingBidders.Shared.Messaging\WeddingBidders.Shared.Messaging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/support/WeddingBidders.Support.Api/appsettings.json
+++ b/services/support/WeddingBidders.Support.Api/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Serilog": {
+    "MinimumLevel": { "Default": "Information" },
+    "WriteTo": [{ "Name": "Console" }],
+    "Properties": { "Application": "SupportService" }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "SupportConnection": "Server=localhost;Database=WeddingBidders_Support;Trusted_Connection=True;TrustServerCertificate=True",
+    "Redis": "localhost:6379"
+  },
+  "Jwt": {
+    "SecretKey": "WeddingBiddersSecretKeyForJwtTokenGenerationMustBe32CharsLong!",
+    "Issuer": "localhost",
+    "Audience": "all",
+    "ExpirationMinutes": 10080
+  },
+  "Cors": { "Origins": "http://localhost:4200" }
+}

--- a/services/support/WeddingBidders.Support.Core/ISupportContext.cs
+++ b/services/support/WeddingBidders.Support.Core/ISupportContext.cs
@@ -1,0 +1,10 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Support.Core.Model;
+
+namespace WeddingBidders.Support.Core;
+
+public interface ISupportContext
+{
+    DbSet<Issue> Issues { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/services/support/WeddingBidders.Support.Core/Model/Issue.cs
+++ b/services/support/WeddingBidders.Support.Core/Model/Issue.cs
@@ -1,0 +1,22 @@
+using WeddingBidders.Shared.Core;
+
+namespace WeddingBidders.Support.Core.Model;
+
+public class Issue : BaseEntity
+{
+    public Guid IssueId { get; set; }
+    public Guid ReportedByProfileId { get; set; }
+    public string Subject { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public IssueStatus Status { get; set; }
+    public string? Resolution { get; set; }
+    public DateTime? ResolvedDate { get; set; }
+}
+
+public enum IssueStatus
+{
+    Open = 0,
+    InProgress = 1,
+    Resolved = 2,
+    Closed = 3
+}

--- a/services/support/WeddingBidders.Support.Core/WeddingBidders.Support.Core.csproj
+++ b/services/support/WeddingBidders.Support.Core/WeddingBidders.Support.Core.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\shared\WeddingBidders.Shared.Core\WeddingBidders.Shared.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/support/WeddingBidders.Support.Infrastructure/Seeding/SupportSeedingService.cs
+++ b/services/support/WeddingBidders.Support.Infrastructure/Seeding/SupportSeedingService.cs
@@ -1,0 +1,19 @@
+using WeddingBidders.Support.Core;
+
+namespace WeddingBidders.Support.Infrastructure.Seeding;
+
+public class SupportSeedingService
+{
+    private readonly ISupportContext _context;
+
+    public SupportSeedingService(ISupportContext context)
+    {
+        _context = context;
+    }
+
+    public async Task SeedAsync()
+    {
+        // Issues are created through the API, no seeding needed
+        await Task.CompletedTask;
+    }
+}

--- a/services/support/WeddingBidders.Support.Infrastructure/SupportContext.cs
+++ b/services/support/WeddingBidders.Support.Infrastructure/SupportContext.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Support.Core;
+using WeddingBidders.Support.Core.Model;
+
+namespace WeddingBidders.Support.Infrastructure;
+
+public class SupportContext : DbContext, ISupportContext
+{
+    public SupportContext(DbContextOptions<SupportContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Issue> Issues => Set<Issue>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Issue>(entity =>
+        {
+            entity.HasKey(i => i.IssueId);
+            entity.Property(i => i.Subject).IsRequired().HasMaxLength(200);
+            entity.Property(i => i.Content).IsRequired();
+            entity.HasQueryFilter(i => !i.IsDeleted);
+        });
+
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/services/support/WeddingBidders.Support.Infrastructure/WeddingBidders.Support.Infrastructure.csproj
+++ b/services/support/WeddingBidders.Support.Infrastructure/WeddingBidders.Support.Infrastructure.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WeddingBidders.Support.Core\WeddingBidders.Support.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/wedding/WeddingBidders.Wedding.Api/Controllers/CustomersController.cs
+++ b/services/wedding/WeddingBidders.Wedding.Api/Controllers/CustomersController.cs
@@ -1,0 +1,40 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using WeddingBidders.Wedding.Api.Features.Customers;
+
+namespace WeddingBidders.Wedding.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class CustomersController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public CustomersController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost("register")]
+    public async Task<ActionResult<CustomerDto>> RegisterCustomer([FromBody] RegisterCustomerRequest request)
+    {
+        try
+        {
+            var customer = await _mediator.Send(request);
+            return CreatedAtAction(nameof(GetAllCustomers), customer);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<CustomerDto>>> GetAllCustomers()
+    {
+        var customers = await _mediator.Send(new GetAllCustomersRequest());
+        return Ok(customers);
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Api/Controllers/WeddingsController.cs
+++ b/services/wedding/WeddingBidders.Wedding.Api/Controllers/WeddingsController.cs
@@ -1,0 +1,69 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using WeddingBidders.Wedding.Api.Features.Weddings;
+
+namespace WeddingBidders.Wedding.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class WeddingsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public WeddingsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<WeddingDto>> CreateWedding([FromBody] CreateWeddingRequest request)
+    {
+        try
+        {
+            var wedding = await _mediator.Send(request);
+            return CreatedAtAction(nameof(GetWeddingById), new { id = wedding.WeddingId }, wedding);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<WeddingDto>> GetWeddingById(Guid id)
+    {
+        var wedding = await _mediator.Send(new GetWeddingByIdRequest { WeddingId = id });
+        if (wedding == null)
+        {
+            return NotFound();
+        }
+        return Ok(wedding);
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<WeddingDto>>> GetAllWeddings()
+    {
+        var weddings = await _mediator.Send(new GetAllWeddingsRequest());
+        return Ok(weddings);
+    }
+
+    [HttpGet("customer/{customerId:guid}")]
+    public async Task<ActionResult<List<WeddingDto>>> GetWeddingsByCustomerId(Guid customerId)
+    {
+        var weddings = await _mediator.Send(new GetWeddingsByCustomerIdRequest { CustomerId = customerId });
+        return Ok(weddings);
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<ActionResult> DeleteWedding(Guid id)
+    {
+        var result = await _mediator.Send(new DeleteWeddingRequest { WeddingId = id });
+        if (!result)
+        {
+            return NotFound();
+        }
+        return NoContent();
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Api/Dockerfile
+++ b/services/wedding/WeddingBidders.Wedding.Api/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["shared/WeddingBidders.Shared.Core/WeddingBidders.Shared.Core.csproj", "shared/WeddingBidders.Shared.Core/"]
+COPY ["shared/WeddingBidders.Shared.Messaging/WeddingBidders.Shared.Messaging.csproj", "shared/WeddingBidders.Shared.Messaging/"]
+COPY ["wedding/WeddingBidders.Wedding.Core/WeddingBidders.Wedding.Core.csproj", "wedding/WeddingBidders.Wedding.Core/"]
+COPY ["wedding/WeddingBidders.Wedding.Infrastructure/WeddingBidders.Wedding.Infrastructure.csproj", "wedding/WeddingBidders.Wedding.Infrastructure/"]
+COPY ["wedding/WeddingBidders.Wedding.Api/WeddingBidders.Wedding.Api.csproj", "wedding/WeddingBidders.Wedding.Api/"]
+RUN dotnet restore "wedding/WeddingBidders.Wedding.Api/WeddingBidders.Wedding.Api.csproj"
+COPY . .
+WORKDIR "/src/wedding/WeddingBidders.Wedding.Api"
+RUN dotnet build "WeddingBidders.Wedding.Api.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "WeddingBidders.Wedding.Api.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "WeddingBidders.Wedding.Api.dll"]

--- a/services/wedding/WeddingBidders.Wedding.Api/Features/Customers/CustomerDto.cs
+++ b/services/wedding/WeddingBidders.Wedding.Api/Features/Customers/CustomerDto.cs
@@ -1,0 +1,27 @@
+using WeddingBidders.Wedding.Core.Model;
+
+namespace WeddingBidders.Wedding.Api.Features.Customers;
+
+public class CustomerDto
+{
+    public Guid CustomerId { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public Guid ProfileId { get; set; }
+}
+
+public static class CustomerExtensions
+{
+    public static CustomerDto ToDto(this Customer customer)
+    {
+        return new CustomerDto
+        {
+            CustomerId = customer.CustomerId,
+            FirstName = customer.FirstName,
+            LastName = customer.LastName,
+            Email = customer.Email,
+            ProfileId = customer.ProfileId
+        };
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Api/Features/Customers/GetAllCustomers.cs
+++ b/services/wedding/WeddingBidders.Wedding.Api/Features/Customers/GetAllCustomers.cs
@@ -1,0 +1,28 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Wedding.Core;
+
+namespace WeddingBidders.Wedding.Api.Features.Customers;
+
+public class GetAllCustomersRequest : IRequest<List<CustomerDto>>
+{
+}
+
+public class GetAllCustomersHandler : IRequestHandler<GetAllCustomersRequest, List<CustomerDto>>
+{
+    private readonly IWeddingContext _context;
+
+    public GetAllCustomersHandler(IWeddingContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<CustomerDto>> Handle(GetAllCustomersRequest request, CancellationToken cancellationToken)
+    {
+        var customers = await _context.Customers
+            .OrderByDescending(c => c.CreatedDate)
+            .ToListAsync(cancellationToken);
+
+        return customers.Select(c => c.ToDto()).ToList();
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Api/Features/Customers/RegisterCustomer.cs
+++ b/services/wedding/WeddingBidders.Wedding.Api/Features/Customers/RegisterCustomer.cs
@@ -1,0 +1,75 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Shared.Core.Events;
+using WeddingBidders.Shared.Messaging;
+using WeddingBidders.Wedding.Core;
+using WeddingBidders.Wedding.Core.Model;
+
+namespace WeddingBidders.Wedding.Api.Features.Customers;
+
+public class RegisterCustomerRequest : IRequest<CustomerDto>
+{
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public Guid ProfileId { get; set; }
+}
+
+public class RegisterCustomerRequestValidator : AbstractValidator<RegisterCustomerRequest>
+{
+    public RegisterCustomerRequestValidator()
+    {
+        RuleFor(x => x.FirstName).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.LastName).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.Email).NotEmpty().EmailAddress();
+        RuleFor(x => x.ProfileId).NotEmpty();
+    }
+}
+
+public class RegisterCustomerHandler : IRequestHandler<RegisterCustomerRequest, CustomerDto>
+{
+    private readonly IWeddingContext _context;
+    private readonly IEventBus _eventBus;
+
+    public RegisterCustomerHandler(IWeddingContext context, IEventBus eventBus)
+    {
+        _context = context;
+        _eventBus = eventBus;
+    }
+
+    public async Task<CustomerDto> Handle(RegisterCustomerRequest request, CancellationToken cancellationToken)
+    {
+        var emailExists = await _context.Customers
+            .AnyAsync(c => c.Email.ToLower() == request.Email.ToLower(), cancellationToken);
+
+        if (emailExists)
+        {
+            throw new InvalidOperationException("Email already registered");
+        }
+
+        var customer = new Customer
+        {
+            CustomerId = Guid.NewGuid(),
+            FirstName = request.FirstName,
+            LastName = request.LastName,
+            Email = request.Email,
+            ProfileId = request.ProfileId,
+            CreatedDate = DateTime.UtcNow
+        };
+
+        _context.Customers.Add(customer);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await _eventBus.PublishAsync(new CustomerRegisteredEvent
+        {
+            CustomerId = customer.CustomerId,
+            ProfileId = customer.ProfileId,
+            Email = customer.Email,
+            FirstName = customer.FirstName,
+            LastName = customer.LastName
+        }, cancellationToken);
+
+        return customer.ToDto();
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Api/Features/Weddings/CreateWedding.cs
+++ b/services/wedding/WeddingBidders.Wedding.Api/Features/Weddings/CreateWedding.cs
@@ -1,0 +1,85 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Shared.Core.Events;
+using WeddingBidders.Shared.Messaging;
+using WeddingBidders.Wedding.Core;
+using WeddingBidders.Wedding.Core.Model;
+
+namespace WeddingBidders.Wedding.Api.Features.Weddings;
+
+public class CreateWeddingRequest : IRequest<WeddingDto>
+{
+    public Guid CustomerId { get; set; }
+    public int NumberOfGuests { get; set; }
+    public int NumberOfHours { get; set; }
+    public string Location { get; set; } = string.Empty;
+    public DateTime Date { get; set; }
+    public List<string> Categories { get; set; } = new();
+}
+
+public class CreateWeddingRequestValidator : AbstractValidator<CreateWeddingRequest>
+{
+    public CreateWeddingRequestValidator()
+    {
+        RuleFor(x => x.CustomerId).NotEmpty();
+        RuleFor(x => x.NumberOfGuests).GreaterThan(0);
+        RuleFor(x => x.NumberOfHours).GreaterThan(0);
+        RuleFor(x => x.Location).NotEmpty().MaximumLength(500);
+        RuleFor(x => x.Date).GreaterThan(DateTime.Now);
+    }
+}
+
+public class CreateWeddingHandler : IRequestHandler<CreateWeddingRequest, WeddingDto>
+{
+    private readonly IWeddingContext _context;
+    private readonly IEventBus _eventBus;
+
+    public CreateWeddingHandler(IWeddingContext context, IEventBus eventBus)
+    {
+        _context = context;
+        _eventBus = eventBus;
+    }
+
+    public async Task<WeddingDto> Handle(CreateWeddingRequest request, CancellationToken cancellationToken)
+    {
+        var customer = await _context.Customers
+            .FirstOrDefaultAsync(c => c.CustomerId == request.CustomerId, cancellationToken);
+
+        if (customer == null)
+        {
+            throw new InvalidOperationException("Customer not found");
+        }
+
+        var wedding = new Core.Model.Wedding
+        {
+            WeddingId = Guid.NewGuid(),
+            CustomerId = request.CustomerId,
+            NumberOfGuests = request.NumberOfGuests,
+            NumberOfHours = request.NumberOfHours,
+            Location = request.Location,
+            Date = request.Date,
+            CreatedDate = DateTime.UtcNow,
+            Categories = request.Categories.Select(c => new Category
+            {
+                CategoryId = Guid.NewGuid(),
+                Name = c,
+                Description = string.Empty
+            }).ToList()
+        };
+
+        _context.Weddings.Add(wedding);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await _eventBus.PublishAsync(new WeddingCreatedEvent
+        {
+            WeddingId = wedding.WeddingId,
+            CustomerId = wedding.CustomerId ?? Guid.Empty,
+            Location = wedding.Location,
+            WeddingDate = wedding.Date,
+            NumberOfGuests = wedding.NumberOfGuests
+        }, cancellationToken);
+
+        return wedding.ToDto();
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Api/Features/Weddings/DeleteWedding.cs
+++ b/services/wedding/WeddingBidders.Wedding.Api/Features/Weddings/DeleteWedding.cs
@@ -1,0 +1,45 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Shared.Core.Events;
+using WeddingBidders.Shared.Messaging;
+using WeddingBidders.Wedding.Core;
+
+namespace WeddingBidders.Wedding.Api.Features.Weddings;
+
+public class DeleteWeddingRequest : IRequest<bool>
+{
+    public Guid WeddingId { get; set; }
+}
+
+public class DeleteWeddingHandler : IRequestHandler<DeleteWeddingRequest, bool>
+{
+    private readonly IWeddingContext _context;
+    private readonly IEventBus _eventBus;
+
+    public DeleteWeddingHandler(IWeddingContext context, IEventBus eventBus)
+    {
+        _context = context;
+        _eventBus = eventBus;
+    }
+
+    public async Task<bool> Handle(DeleteWeddingRequest request, CancellationToken cancellationToken)
+    {
+        var wedding = await _context.Weddings
+            .FirstOrDefaultAsync(w => w.WeddingId == request.WeddingId, cancellationToken);
+
+        if (wedding == null)
+        {
+            return false;
+        }
+
+        wedding.IsDeleted = true;
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await _eventBus.PublishAsync(new WeddingDeletedEvent
+        {
+            WeddingId = wedding.WeddingId
+        }, cancellationToken);
+
+        return true;
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Api/Features/Weddings/GetAllWeddings.cs
+++ b/services/wedding/WeddingBidders.Wedding.Api/Features/Weddings/GetAllWeddings.cs
@@ -1,0 +1,29 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Wedding.Core;
+
+namespace WeddingBidders.Wedding.Api.Features.Weddings;
+
+public class GetAllWeddingsRequest : IRequest<List<WeddingDto>>
+{
+}
+
+public class GetAllWeddingsHandler : IRequestHandler<GetAllWeddingsRequest, List<WeddingDto>>
+{
+    private readonly IWeddingContext _context;
+
+    public GetAllWeddingsHandler(IWeddingContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<WeddingDto>> Handle(GetAllWeddingsRequest request, CancellationToken cancellationToken)
+    {
+        var weddings = await _context.Weddings
+            .Include(w => w.Categories)
+            .OrderByDescending(w => w.CreatedDate)
+            .ToListAsync(cancellationToken);
+
+        return weddings.Select(w => w.ToDto()).ToList();
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Api/Features/Weddings/GetWeddingById.cs
+++ b/services/wedding/WeddingBidders.Wedding.Api/Features/Weddings/GetWeddingById.cs
@@ -1,0 +1,29 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Wedding.Core;
+
+namespace WeddingBidders.Wedding.Api.Features.Weddings;
+
+public class GetWeddingByIdRequest : IRequest<WeddingDto?>
+{
+    public Guid WeddingId { get; set; }
+}
+
+public class GetWeddingByIdHandler : IRequestHandler<GetWeddingByIdRequest, WeddingDto?>
+{
+    private readonly IWeddingContext _context;
+
+    public GetWeddingByIdHandler(IWeddingContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<WeddingDto?> Handle(GetWeddingByIdRequest request, CancellationToken cancellationToken)
+    {
+        var wedding = await _context.Weddings
+            .Include(w => w.Categories)
+            .FirstOrDefaultAsync(w => w.WeddingId == request.WeddingId, cancellationToken);
+
+        return wedding?.ToDto();
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Api/Features/Weddings/GetWeddingsByCustomerId.cs
+++ b/services/wedding/WeddingBidders.Wedding.Api/Features/Weddings/GetWeddingsByCustomerId.cs
@@ -1,0 +1,31 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Wedding.Core;
+
+namespace WeddingBidders.Wedding.Api.Features.Weddings;
+
+public class GetWeddingsByCustomerIdRequest : IRequest<List<WeddingDto>>
+{
+    public Guid CustomerId { get; set; }
+}
+
+public class GetWeddingsByCustomerIdHandler : IRequestHandler<GetWeddingsByCustomerIdRequest, List<WeddingDto>>
+{
+    private readonly IWeddingContext _context;
+
+    public GetWeddingsByCustomerIdHandler(IWeddingContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<WeddingDto>> Handle(GetWeddingsByCustomerIdRequest request, CancellationToken cancellationToken)
+    {
+        var weddings = await _context.Weddings
+            .Include(w => w.Categories)
+            .Where(w => w.CustomerId == request.CustomerId)
+            .OrderByDescending(w => w.CreatedDate)
+            .ToListAsync(cancellationToken);
+
+        return weddings.Select(w => w.ToDto()).ToList();
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Api/Features/Weddings/WeddingDto.cs
+++ b/services/wedding/WeddingBidders.Wedding.Api/Features/Weddings/WeddingDto.cs
@@ -1,0 +1,41 @@
+namespace WeddingBidders.Wedding.Api.Features.Weddings;
+
+public class WeddingDto
+{
+    public Guid WeddingId { get; set; }
+    public int NumberOfGuests { get; set; }
+    public int NumberOfHours { get; set; }
+    public string Location { get; set; } = string.Empty;
+    public DateTime Date { get; set; }
+    public Guid? CustomerId { get; set; }
+    public List<CategoryDto> Categories { get; set; } = new();
+}
+
+public class CategoryDto
+{
+    public Guid CategoryId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+}
+
+public static class WeddingExtensions
+{
+    public static WeddingDto ToDto(this Core.Model.Wedding wedding)
+    {
+        return new WeddingDto
+        {
+            WeddingId = wedding.WeddingId,
+            NumberOfGuests = wedding.NumberOfGuests,
+            NumberOfHours = wedding.NumberOfHours,
+            Location = wedding.Location,
+            Date = wedding.Date,
+            CustomerId = wedding.CustomerId,
+            Categories = wedding.Categories.Select(c => new CategoryDto
+            {
+                CategoryId = c.CategoryId,
+                Name = c.Name,
+                Description = c.Description
+            }).ToList()
+        };
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Api/Program.cs
+++ b/services/wedding/WeddingBidders.Wedding.Api/Program.cs
@@ -1,0 +1,150 @@
+using System.Text;
+using FluentValidation;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using Serilog;
+using WeddingBidders.Shared.Messaging;
+using WeddingBidders.Wedding.Core;
+using WeddingBidders.Wedding.Infrastructure;
+using WeddingBidders.Wedding.Infrastructure.Seeding;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Configure Serilog
+Log.Logger = new LoggerConfiguration()
+    .ReadFrom.Configuration(builder.Configuration)
+    .Enrich.FromLogContext()
+    .WriteTo.Console()
+    .CreateLogger();
+
+builder.Host.UseSerilog();
+
+// Add services to the container
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Wedding Service API", Version = "v1" });
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Description = "JWT Authorization header using the Bearer scheme",
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = "Bearer"
+    });
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+});
+
+// Database - Wedding Service has its own database
+builder.Services.AddDbContext<WeddingContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("WeddingConnection")));
+builder.Services.AddScoped<IWeddingContext>(sp => sp.GetRequiredService<WeddingContext>());
+builder.Services.AddScoped<WeddingSeedingService>();
+
+// Redis Event Bus with MessagePack serialization
+builder.Services.AddRedisEventBus(builder.Configuration.GetConnectionString("Redis")!);
+
+// MediatR
+builder.Services.AddMediatR(cfg =>
+{
+    cfg.RegisterServicesFromAssembly(typeof(Program).Assembly);
+});
+
+// FluentValidation
+builder.Services.AddValidatorsFromAssembly(typeof(Program).Assembly);
+
+// Authorization
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddAuthorization();
+
+// JWT Authentication
+var jwtKey = builder.Configuration["Jwt:SecretKey"]!;
+var jwtIssuer = builder.Configuration["Jwt:Issuer"]!;
+var jwtAudience = builder.Configuration["Jwt:Audience"]!;
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddJwtBearer(options =>
+{
+    options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
+    options.SaveToken = true;
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey)),
+        ValidateIssuer = true,
+        ValidIssuer = jwtIssuer,
+        ValidateAudience = true,
+        ValidAudience = jwtAudience,
+        ValidateLifetime = true,
+        ClockSkew = TimeSpan.Zero
+    };
+});
+
+// CORS
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("CorsPolicy", policy =>
+    {
+        var origins = builder.Configuration["Cors:Origins"]?.Split(',') ?? Array.Empty<string>();
+        policy.WithOrigins(origins)
+            .AllowAnyMethod()
+            .AllowAnyHeader()
+            .AllowCredentials();
+    });
+});
+
+var app = builder.Build();
+
+// Seed database
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider.GetRequiredService<WeddingContext>();
+
+    if (app.Environment.IsDevelopment())
+    {
+        await context.Database.EnsureCreatedAsync();
+        var seeder = scope.ServiceProvider.GetRequiredService<WeddingSeedingService>();
+        await seeder.SeedAsync();
+    }
+}
+
+// Configure the HTTP request pipeline
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseCors("CorsPolicy");
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.UseSerilogRequestLogging();
+
+app.MapControllers();
+
+app.Run();
+
+public partial class Program { }

--- a/services/wedding/WeddingBidders.Wedding.Api/WeddingBidders.Wedding.Api.csproj
+++ b/services/wedding/WeddingBidders.Wedding.Api/WeddingBidders.Wedding.Api.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="MediatR" Version="12.2.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WeddingBidders.Wedding.Core\WeddingBidders.Wedding.Core.csproj" />
+    <ProjectReference Include="..\WeddingBidders.Wedding.Infrastructure\WeddingBidders.Wedding.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\shared\WeddingBidders.Shared.Messaging\WeddingBidders.Shared.Messaging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/wedding/WeddingBidders.Wedding.Api/appsettings.json
+++ b/services/wedding/WeddingBidders.Wedding.Api/appsettings.json
@@ -1,0 +1,47 @@
+{
+  "Serilog": {
+    "Using": ["Serilog.Sinks.Console", "Serilog.Sinks.File"],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning",
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}"
+        }
+      },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "logs/wedding-service-.log",
+          "rollingInterval": "Day"
+        }
+      }
+    ],
+    "Enrich": ["FromLogContext", "WithMachineName", "WithEnvironmentName"],
+    "Properties": {
+      "Application": "WeddingService"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "WeddingConnection": "Server=localhost;Database=WeddingBidders_Wedding;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True",
+    "Redis": "localhost:6379"
+  },
+  "Jwt": {
+    "SecretKey": "WeddingBiddersSecretKeyForJwtTokenGenerationMustBe32CharsLong!",
+    "Issuer": "localhost",
+    "Audience": "all",
+    "ExpirationMinutes": 10080
+  },
+  "Cors": {
+    "Origins": "http://localhost:4200"
+  }
+}

--- a/services/wedding/WeddingBidders.Wedding.Core/IWeddingContext.cs
+++ b/services/wedding/WeddingBidders.Wedding.Core/IWeddingContext.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Wedding.Core.Model;
+
+namespace WeddingBidders.Wedding.Core;
+
+public interface IWeddingContext
+{
+    DbSet<Model.Wedding> Weddings { get; }
+    DbSet<Customer> Customers { get; }
+    DbSet<Category> Categories { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/services/wedding/WeddingBidders.Wedding.Core/Model/Category.cs
+++ b/services/wedding/WeddingBidders.Wedding.Core/Model/Category.cs
@@ -1,0 +1,10 @@
+namespace WeddingBidders.Wedding.Core.Model;
+
+public class Category
+{
+    public Guid CategoryId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public Guid WeddingId { get; set; }
+    public Wedding? Wedding { get; set; }
+}

--- a/services/wedding/WeddingBidders.Wedding.Core/Model/Customer.cs
+++ b/services/wedding/WeddingBidders.Wedding.Core/Model/Customer.cs
@@ -1,0 +1,13 @@
+using WeddingBidders.Shared.Core;
+
+namespace WeddingBidders.Wedding.Core.Model;
+
+public class Customer : BaseEntity
+{
+    public Guid CustomerId { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public Guid ProfileId { get; set; }
+    public ICollection<Wedding> Weddings { get; set; } = new List<Wedding>();
+}

--- a/services/wedding/WeddingBidders.Wedding.Core/Model/Wedding.cs
+++ b/services/wedding/WeddingBidders.Wedding.Core/Model/Wedding.cs
@@ -1,0 +1,15 @@
+using WeddingBidders.Shared.Core;
+
+namespace WeddingBidders.Wedding.Core.Model;
+
+public class Wedding : BaseEntity
+{
+    public Guid WeddingId { get; set; }
+    public int NumberOfGuests { get; set; }
+    public int NumberOfHours { get; set; }
+    public string Location { get; set; } = string.Empty;
+    public DateTime Date { get; set; }
+    public Guid? CustomerId { get; set; }
+    public Customer? Customer { get; set; }
+    public ICollection<Category> Categories { get; set; } = new List<Category>();
+}

--- a/services/wedding/WeddingBidders.Wedding.Core/WeddingBidders.Wedding.Core.csproj
+++ b/services/wedding/WeddingBidders.Wedding.Core/WeddingBidders.Wedding.Core.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\shared\WeddingBidders.Shared.Core\WeddingBidders.Shared.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/wedding/WeddingBidders.Wedding.Infrastructure/Configurations/CategoryConfiguration.cs
+++ b/services/wedding/WeddingBidders.Wedding.Infrastructure/Configurations/CategoryConfiguration.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WeddingBidders.Wedding.Core.Model;
+
+namespace WeddingBidders.Wedding.Infrastructure.Configurations;
+
+public class CategoryConfiguration : IEntityTypeConfiguration<Category>
+{
+    public void Configure(EntityTypeBuilder<Category> builder)
+    {
+        builder.HasKey(c => c.CategoryId);
+        builder.Property(c => c.Name).IsRequired().HasMaxLength(100);
+        builder.Property(c => c.Description).HasMaxLength(500);
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Infrastructure/Configurations/CustomerConfiguration.cs
+++ b/services/wedding/WeddingBidders.Wedding.Infrastructure/Configurations/CustomerConfiguration.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WeddingBidders.Wedding.Core.Model;
+
+namespace WeddingBidders.Wedding.Infrastructure.Configurations;
+
+public class CustomerConfiguration : IEntityTypeConfiguration<Customer>
+{
+    public void Configure(EntityTypeBuilder<Customer> builder)
+    {
+        builder.HasKey(c => c.CustomerId);
+        builder.Property(c => c.FirstName).IsRequired().HasMaxLength(100);
+        builder.Property(c => c.LastName).IsRequired().HasMaxLength(100);
+        builder.Property(c => c.Email).IsRequired().HasMaxLength(255);
+        builder.HasIndex(c => c.Email).IsUnique();
+        builder.HasQueryFilter(c => !c.IsDeleted);
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Infrastructure/Configurations/WeddingConfiguration.cs
+++ b/services/wedding/WeddingBidders.Wedding.Infrastructure/Configurations/WeddingConfiguration.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace WeddingBidders.Wedding.Infrastructure.Configurations;
+
+public class WeddingConfiguration : IEntityTypeConfiguration<Core.Model.Wedding>
+{
+    public void Configure(EntityTypeBuilder<Core.Model.Wedding> builder)
+    {
+        builder.HasKey(w => w.WeddingId);
+        builder.Property(w => w.Location).IsRequired().HasMaxLength(500);
+        builder.HasQueryFilter(w => !w.IsDeleted);
+
+        builder.HasOne(w => w.Customer)
+            .WithMany(c => c.Weddings)
+            .HasForeignKey(w => w.CustomerId);
+
+        builder.HasMany(w => w.Categories)
+            .WithOne(c => c.Wedding)
+            .HasForeignKey(c => c.WeddingId);
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Infrastructure/Seeding/WeddingSeedingService.cs
+++ b/services/wedding/WeddingBidders.Wedding.Infrastructure/Seeding/WeddingSeedingService.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Wedding.Core;
+
+namespace WeddingBidders.Wedding.Infrastructure.Seeding;
+
+public class WeddingSeedingService
+{
+    private readonly IWeddingContext _context;
+
+    public WeddingSeedingService(IWeddingContext context)
+    {
+        _context = context;
+    }
+
+    public async Task SeedAsync()
+    {
+        await SeedCategoriesAsync();
+        await _context.SaveChangesAsync();
+    }
+
+    private async Task SeedCategoriesAsync()
+    {
+        // Categories are created per wedding, no global seeding needed
+        // This method is here for future seeding needs
+        await Task.CompletedTask;
+    }
+}

--- a/services/wedding/WeddingBidders.Wedding.Infrastructure/WeddingBidders.Wedding.Infrastructure.csproj
+++ b/services/wedding/WeddingBidders.Wedding.Infrastructure/WeddingBidders.Wedding.Infrastructure.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WeddingBidders.Wedding.Core\WeddingBidders.Wedding.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/wedding/WeddingBidders.Wedding.Infrastructure/WeddingContext.cs
+++ b/services/wedding/WeddingBidders.Wedding.Infrastructure/WeddingContext.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingBidders.Wedding.Core;
+using WeddingBidders.Wedding.Core.Model;
+
+namespace WeddingBidders.Wedding.Infrastructure;
+
+public class WeddingContext : DbContext, IWeddingContext
+{
+    public WeddingContext(DbContextOptions<WeddingContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Core.Model.Wedding> Weddings => Set<Core.Model.Wedding>();
+    public DbSet<Customer> Customers => Set<Customer>();
+    public DbSet<Category> Categories => Set<Category>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(WeddingContext).Assembly);
+        base.OnModelCreating(modelBuilder);
+    }
+}


### PR DESCRIPTION
- Split monolith into 6 microservices: Identity, Wedding, Bidding, Messaging, Subscription, Support
- Each microservice has its own database with EF Core context and seeding
- Implemented Redis Pub/Sub for inter-service communication
- Used MessagePack for efficient binary serialization of events
- Created shared libraries for common functionality (events, messaging)
- Added YARP-based API Gateway for routing requests
- Included Docker support with docker-compose.microservices.yml

Microservices:
- Identity Service: User, Role, Privilege, Profile, Account management
- Wedding Service: Wedding, Customer, Category management
- Bidding Service: Bidder, Bid, Gallery management
- Messaging Service: Message, Conversation management
- Subscription Service: Subscription, Plan, Payment management
- Support Service: Issue/ticket management